### PR TITLE
Allow saving raw data in the post-processing step

### DIFF
--- a/plantseg/dataprocessing/dataprocessing.py
+++ b/plantseg/dataprocessing/dataprocessing.py
@@ -42,7 +42,8 @@ class DataPostProcessing3D(GenericPipelineStep):
                  save_directory="PostProcessing",
                  factor=None,
                  out_ext=".h5",
-                 state=True):
+                 state=True,
+                 save_raw=False):
         if factor is None:
             factor = [1, 1, 1]
 
@@ -54,7 +55,8 @@ class DataPostProcessing3D(GenericPipelineStep):
                          save_directory=save_directory,
                          out_ext=out_ext,
                          state=state,
-                         h5_output_key=h5_output_key)
+                         h5_output_key=h5_output_key,
+                         save_raw=save_raw)
 
         # rescaling
         self.factor = factor

--- a/plantseg/gui/gui_widgets.py
+++ b/plantseg/gui/gui_widgets.py
@@ -364,7 +364,7 @@ class PostSegmentationFrame(ModuleFramePrototype):
          for i, w in enumerate(self.post_style["columns_weights"])]
 
         super().__init__(self.post_frame, module_name, font=font)
-        self.module = "cnn_postprocessing"
+        self.module = "segmentation_postprocessing"
         self.config = config
 
         self.show = tkinter.BooleanVar()
@@ -383,6 +383,13 @@ class PostSegmentationFrame(ModuleFramePrototype):
                                              column=0,
                                              menu=["True", "False"],
                                              default=self.config[self.module]["tiff"],
+                                             font=font),
+                           "save_raw": MenuEntry(self.post_frame,
+                                             text="Save raw data: ",
+                                             row=4,
+                                             column=0,
+                                             menu=["True", "False"],
+                                             default=self.config[self.module].get("save_raw", "False"),
                                              font=font),
                            }
 
@@ -441,7 +448,14 @@ class PostPredictionsFrame(ModuleFramePrototype):
                                                     column=0,
                                                     menu=["data_uint8", "data_float32"],
                                                     default=config[self.module]["output_type"],
-                                                    font=font)
+                                                    font=font),
+                           "save_raw": MenuEntry(self.post_frame,
+                                                 text="Save raw data: ",
+                                                 row=7,
+                                                 column=0,
+                                                 menu=["True", "False"],
+                                                 default=self.config[self.module].get("save_raw", "False"),
+                                                 font=font),
                            }
 
         self.show_options()

--- a/plantseg/pipeline/raw2seg.py
+++ b/plantseg/pipeline/raw2seg.py
@@ -42,8 +42,10 @@ def _create_postprocessing_step(input_paths, input_type, config):
     factor = config.get('factor', [1, 1, 1])
     out_ext = ".tiff" if config["tiff"] else ".h5"
     state = config.get('state', True)
+    save_raw = config.get('save_raw', False)
     return DataPostProcessing3D(input_paths, input_type=input_type, output_type=output_type,
-                                save_directory=save_directory, factor=factor, out_ext=out_ext, state=state)
+                                save_directory=save_directory, factor=factor, out_ext=out_ext,
+                                state=state, save_raw=save_raw)
 
 
 def raw2seg(config):

--- a/plantseg/resources/config_gui_template.yaml
+++ b/plantseg/resources/config_gui_template.yaml
@@ -46,6 +46,8 @@ cnn_postprocessing:
   factor: [1, 1, 1]
   # spline order for rescaling
   order: 2
+  # save raw input in the output prediction file h5 file
+  save_raw: False
 
 
 segmentation:
@@ -82,6 +84,8 @@ segmentation_postprocessing:
   factor: [1, 1, 1]
   # spline order for rescaling (keep 0 for segmentation post processing
   order: 0
+  # save raw input in the output segmentation file h5 file
+  save_raw: False
 
 
 


### PR DESCRIPTION
- [x] add drop-down elements to the post-processing of CNN predictions / segmentation which allows to save the raw data in the H5
- [x] bug fix: wrong module name in the `PostSegmentationFrame`