### PR TITLE
correct link to local model file

### DIFF
--- a/bioimage-io/UNet2DArabidopsisOvules.model/UNet2DArabidopsisOvules.model.yaml
+++ b/bioimage-io/UNet2DArabidopsisOvules.model/UNet2DArabidopsisOvules.model.yaml
@@ -23,7 +23,7 @@ framework: pytorch
 
 documentation: ./unet2d.md
 
-source: ./unet.py:UNet2D
+source: unet.py::UNet2D
 # additional model parameters
 kwargs:
   in_channels: 1

--- a/bioimage-io/UNet3DArabidopsisOvules.model/UNet3DArabidopsisOvules.model.yaml
+++ b/bioimage-io/UNet3DArabidopsisOvules.model/UNet3DArabidopsisOvules.model.yaml
@@ -23,7 +23,7 @@ framework: pytorch
 
 documentation: ./unet3d.md
 
-source: ./unet.py:UNet3D
+source: unet.py::UNet3D
 # additional model parameters
 kwargs:
   in_channels: 1

--- a/bioimage-io/UNet3DLateralRoot.model/UNet3DLateralRoot.model.yaml
+++ b/bioimage-io/UNet3DLateralRoot.model/UNet3DLateralRoot.model.yaml
@@ -23,7 +23,7 @@ framework: pytorch
 
 documentation: ./unet3d.md
 
-source: ./unet.py:UNet3D
+source: unet.py::UNet3D
 # additional model parameters
 kwargs:
   in_channels: 1

--- a/bioimage-io/UNet3DLateralRootNuclei.model/UNet3DLateralRootNuclei.model.yaml
+++ b/bioimage-io/UNet3DLateralRootNuclei.model/UNet3DLateralRootNuclei.model.yaml
@@ -23,7 +23,7 @@ framework: pytorch
 
 documentation: ./unet3d.md
 
-source: ./unet.py:UNet3D
+source: unet.py::UNet3D
 # additional model parameters
 kwargs:
   in_channels: 1


### PR DESCRIPTION
it seems to be necessary to specify the link to the source file without the leading `./`, at least currently. In principle this should be supported, too, but for now it's easier to fix the models.