### PR TITLE
run plant seg by specifing a dir path

### DIFF
--- a/plantseg/pipeline/config_validation.py
+++ b/plantseg/pipeline/config_validation.py
@@ -8,7 +8,7 @@ import yaml
 from plantseg.gui import list_models
 from plantseg.pipeline import gui_logger
 from plantseg.pipeline import raw2seg_config_template
-from plantseg.predictions.utils import STRIDE_ACCURATE, STRIDE_BALANCED, STRIDE_DRAFT, get_stride_shape
+from plantseg.predictions.utils import STRIDE_ACCURATE, STRIDE_BALANCED, STRIDE_DRAFT, get_stride_shape, check_models
 from plantseg.segmentation.utils import SUPPORTED_ALGORITMS
 
 deprecated_keys = {'param': 'filter_param'}
@@ -103,7 +103,7 @@ def is_file_or_dir(key, value, fallback):
 
 def model_exist(key, value, fallback):
     _list_models = list_models()
-    if value not in _list_models:
+    if value not in _list_models and not check_models(value):
         _error_message(f"value must be one of {_list_models}", key, value, fallback)
         return fallback
     else:

--- a/plantseg/predictions/utils.py
+++ b/plantseg/predictions/utils.py
@@ -125,11 +125,13 @@ def check_models(model_name, update_files=False):
     """
     Simple script to check and download trained modules
     """
-    model_dir = os.path.join(os.path.expanduser("~"), PLANTSEG_MODELS_DIR, model_name)
-
-    # Check if model directory exist if not create it
-    if ~os.path.exists(model_dir):
-        os.makedirs(model_dir, exist_ok=True)
+    if os.path.isdir(model_name):
+        model_dir = model_name
+    else:
+        model_dir = os.path.join(os.path.expanduser("~"), PLANTSEG_MODELS_DIR, model_name)
+        # Check if model directory exist if not create it
+        if ~os.path.exists(model_dir):
+            os.makedirs(model_dir, exist_ok=True)
 
     model_config_path = os.path.exists(os.path.join(model_dir, CONFIG_TRAIN_YAML))
     model_best_path = os.path.exists(os.path.join(model_dir, BEST_MODEL_PYTORCH))
@@ -154,3 +156,4 @@ def check_models(model_name, update_files=False):
             wget.download(url + LAST_MODEL_PYTORCH, out=model_dir)
         else:
             raise RuntimeError(f"Custom model {model_name} corrupted. Required files not found.")
+    return True


### PR DESCRIPTION
A small PR that add the functionality to run predictions from path and not only by "name".

This should make no difference for normal plantseg user, but makes way easier to script hyperparamers search. 

example:
```
cnn_prediction:
  ...
  model_name: /home/user/experiment/new_model/
  ...
```

Of course plantseg will check if all files are in the directory and raise and error if the files are not there.
