### PR TITLE
Fix CNN prediction rescaling

### DIFF
--- a/plantseg/gui/gui_tools.py
+++ b/plantseg/gui/gui_tools.py
@@ -10,8 +10,7 @@ from plantseg import custom_zoo, home_path, PLANTSEG_MODELS_DIR, model_zoo_path
 from plantseg.__version__ import __version__
 from plantseg.gui import stick_all, stick_ew, var_to_tkinter, convert_rgb, PLANTSEG_GREEN
 from plantseg.pipeline import gui_logger
-from plantseg.pipeline.steps import H5_EXTENSIONS, TIFF_EXTENSIONS
-from plantseg.pipeline.utils import read_tiff_voxel_size, read_h5_voxel_size
+from plantseg.pipeline.utils import read_tiff_voxel_size, read_h5_voxel_size, TIFF_EXTENSIONS, H5_EXTENSIONS
 
 current_model = None
 current_segmentation = None


### PR DESCRIPTION
- [x] Fix CNN prediction rescaling (`zoom` function from scipy uses rounding to compute the output shape based on the zoom factor; doing scaling (pre-processing) and re-scaling (post-processing) may lead to incorrect output shape and segmentation errors, e.g. in LiftedMulticut
- [x] Fix voxel size after rescaling