### PR TITLE
Update LiftedMulticut with nucleus segmentation

### DIFF
--- a/plantseg/segmentation/functional/segmentation.py
+++ b/plantseg/segmentation/functional/segmentation.py
@@ -216,8 +216,6 @@ def lifted_multicut_from_nuclei_segmentation(boundary_pmaps: ArrayLike,
 
     # solve the full lifted problem using the kernighan lin approximation introduced in
     # http://openaccess.thecvf.com/content_iccv_2015/html/Keuper_Efficient_Decomposition_of_ICCV_2015_paper.html
-    lifted_costs = lifted_costs.astype('float64')
-    lifted_costs = lifted_costs[:, 0]
     node_labels = lmc.lifted_multicut_kernighan_lin(rag, costs, lifted_uvs, lifted_costs)
     segmentation = project_node_labels_to_pixels(rag, node_labels)
 


### PR DESCRIPTION
Found the code not working when I was doing LMC yesterday. `lifted_costs` is now created as a 1D `float64` array, `lifted_costs = np.zeros(len(lifted_labels), dtype="float64")`, in `elf`'s `lifted_problem_from_segmentation()`. Should fix #109 as well.