### PR TITLE
Add option to set home_path via PLANTSEG_HOME env-variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,11 @@ Selecting a given network name (either in the config file or GUI) will download 
 directory.
 Detailed description of network training can be found in our [paper](#citation).
 
+The PlantSeg home directory can be configured with the `PLANTSEG_HOME` environment variable.
+```bash
+export PLANTSEG_HOME="/path/to/plantseg/home"
+```
+
 ## Training on New Data
 For training new models we rely on the [pytorch-3dunet](https://github.com/wolny/pytorch-3dunet). 
 A similar configuration file can be used for training on new data and all the instructions can be found in the repo.

--- a/plantseg/__init__.py
+++ b/plantseg/__init__.py
@@ -7,7 +7,10 @@ import yaml
 plantseg_global_path = Path(__file__).parent.absolute()
 
 # Create configs directory at startup
-home_path = os.path.expanduser("~")
+if 'PLANTSEG_HOME' in os.environ:
+    home_path = os.environ['PLANTSEG_HOME']
+else:
+    home_path = os.path.expanduser("~")
 PLANTSEG_MODELS_DIR = ".plantseg_models"
 
 configs_path = os.path.join(home_path, PLANTSEG_MODELS_DIR, "configs")


### PR DESCRIPTION
Hi,

I would like to make the PlantSeg home directory configurable and added the option to set the `PLANTSEG_HOME` environment variable. 

Cheers