### PR TITLE
Add widget: remove objects using a probability map

### DIFF
--- a/plantseg/segmentation/functional/segmentation.py
+++ b/plantseg/segmentation/functional/segmentation.py
@@ -76,9 +76,7 @@ def gasp(boundary_pmaps: np.array,
          gasp_linkage_criteria: str = 'average',
          beta: float = 0.5,
          post_minsize: int = 100,
-         n_threads: int = 6,
-         foreground_pmap: np.array = None,
-         foreground_threshold: float = 0.6) -> np.array:
+         n_threads: int = 6) -> np.array:
     """
     Implementation of the GASP algorithm for segmentation from affinities.
 
@@ -136,13 +134,6 @@ def gasp(boundary_pmaps: np.array,
     # init and run size threshold
     if post_minsize > 0:
         segmentation, _ = apply_size_filter(segmentation.astype('uint32'), boundary_pmaps, post_minsize)
-
-    if foreground_pmap is not None:
-        segmentation = remove_false_positives_by_foreground_probability(
-            segmentation,
-            foreground_pmap,
-            foreground_threshold,
-        )
     return segmentation
 
 

--- a/plantseg/segmentation/gasp.py
+++ b/plantseg/segmentation/gasp.py
@@ -62,10 +62,6 @@ class GaspFromPmaps(AbstractSegmentationStep):
                                     stacked=ws_2D, sigma_weights=ws_w_sigma,
                                     min_size=ws_minsize, n_threads=n_threads)
 
-        # Postprocessing foreground probability map
-        self.foreground_pmap = kwargs.get('foreground_pmap', None)
-        self.foreground_threshold = kwargs.get('foreground_threshold', 0.6)
-
     def process(self, pmaps):
         # start real world clock timer
         runtime = time.time()
@@ -86,9 +82,7 @@ class GaspFromPmaps(AbstractSegmentationStep):
                             gasp_linkage_criteria=self.gasp_linkage_criteria,
                             beta=self.beta,
                             post_minsize=self.post_minsize,
-                            n_threads=self.n_threads,
-                            foreground_pmap=self.foreground_pmap,
-                            foreground_threshold=self.foreground_threshold,)
+                            n_threads=self.n_threads)
 
         # stop real world clock timer
         runtime = time.time() - runtime

--- a/plantseg/segmentation/gasp.py
+++ b/plantseg/segmentation/gasp.py
@@ -56,13 +56,15 @@ class GaspFromPmaps(AbstractSegmentationStep):
 
         # Postprocessing size threshold
         self.post_minsize = post_minsize
-
         self.n_threads = n_threads
-
         self.dt_watershed = partial(dt_watershed,
                                     threshold=ws_threshold, sigma_seeds=ws_sigma,
                                     stacked=ws_2D, sigma_weights=ws_w_sigma,
                                     min_size=ws_minsize, n_threads=n_threads)
+
+        # Postprocessing foreground probability map
+        self.foreground_pmap = kwargs.get('foreground_pmap', None)
+        self.foreground_threshold = kwargs.get('foreground_threshold', 0.6)
 
     def process(self, pmaps):
         # start real world clock timer
@@ -84,7 +86,9 @@ class GaspFromPmaps(AbstractSegmentationStep):
                             gasp_linkage_criteria=self.gasp_linkage_criteria,
                             beta=self.beta,
                             post_minsize=self.post_minsize,
-                            n_threads=self.n_threads)
+                            n_threads=self.n_threads,
+                            foreground_pmap=self.foreground_pmap,
+                            foreground_threshold=self.foreground_threshold,)
 
         # stop real world clock timer
         runtime = time.time() - runtime

--- a/plantseg/viewer/containers.py
+++ b/plantseg/viewer/containers.py
@@ -13,6 +13,7 @@ from plantseg.viewer.widget.proofreading.proofreading import widget_clean_scribb
 from plantseg.viewer.widget.proofreading.proofreading import widget_split_and_merge_from_scribbles
 from plantseg.viewer.widget.segmentation import widget_dt_ws, widget_agglomeration
 from plantseg.viewer.widget.segmentation import widget_fix_over_under_segmentation_from_nuclei
+from plantseg.viewer.widget.segmentation import widget_fix_false_positive_from_foreground_pmap
 from plantseg.viewer.widget.segmentation import widget_lifted_multicut
 from plantseg.viewer.widget.segmentation import widget_simple_dt_ws
 
@@ -65,7 +66,8 @@ def get_gasp_workflow():
 def get_extra_seg():
     container = MainWindow(widgets=[widget_dt_ws,
                                     widget_lifted_multicut,
-                                    widget_fix_over_under_segmentation_from_nuclei],
+                                    widget_fix_over_under_segmentation_from_nuclei,
+                                    widget_fix_false_positive_from_foreground_pmap],
                            labels=False)
     container = setup_menu(container, path='https://hci-unihd.github.io/plant-seg/chapters/plantseg_interactive_napari/extra_seg.html')
     return container

--- a/plantseg/viewer/widget/predictions.py
+++ b/plantseg/viewer/widget/predictions.py
@@ -18,7 +18,7 @@ from plantseg.viewer.logging import napari_formatted_logging
 from plantseg.viewer.widget.proofreading.proofreading import widget_split_and_merge_from_scribbles
 from plantseg.viewer.widget.segmentation import widget_agglomeration, widget_lifted_multicut, widget_simple_dt_ws
 from plantseg.viewer.widget.utils import return_value_if_widget
-from plantseg.viewer.widget.utils import start_threading_process, start_prediction_threading_process, create_layer_name, layer_properties
+from plantseg.viewer.widget.utils import start_threading_process, start_prediction_process, create_layer_name, layer_properties
 
 ALL_CUDA_DEVICES = [f'cuda:{i}' for i in range(torch.cuda.device_count())]
 MPS = ['mps'] if torch.backends.mps.is_available() else []
@@ -87,9 +87,9 @@ def widget_unet_predictions(viewer: Viewer,
     layer_type = 'image'
     step_kwargs = dict(model_name=model_name, patch=patch_size, single_batch_mode=single_patch)
 
-    return start_prediction_threading_process(unet_predictions_wrapper,
-                                   runtime_kwargs={'raw': image.data, 
-                                                   'device': device, 
+    return start_prediction_process(unet_predictions_wrapper,
+                                   runtime_kwargs={'raw': image.data,
+                                                   'device': device,
                                                    'handle_multichannel': True},
                                    statics_kwargs=step_kwargs,
                                    out_name=out_name,


### PR DESCRIPTION
### A generic pmap-guided object removal widget 
Instead of adding an option to each "boundary -> segmentation" algorithm as discussed in #174, I made a separate widget for Napari GUI pipeline for generic usage. This independent design avoids bundled computation within other functions such as GASP, allows easy trial-and-error strategy, accepts flexible input pmaps/images and threshold, and is useful in unexpected use cases.

I came up with three designs and decided to implement only one. I now add this to Napari, and will think about the best way to do it in the other UI. 

1. **Method 1:** Threshold foreground to a binary mask and multiply with the segmentation pixel-wise ❌
   1. **Pros:** very fast; false positive parts will be deleted within objects if foreground quality is high
   2. **Cons:** depending on the quality of foreground segmentation, details may be lost
2. **Method 2:** Delete instances based on the centroids' value in foreground ❌
   1. **Pros:** more educated guesses than 1, preserves details
   2. **Cons:** merged instances or merged false-and-true instances will be deleted together; not helpful if instances are not star-convex, e.g. C shaped false positives around objects will persist
3. **Method 3:** Delete instances that has, say, 90% overlap with the background (I believe it's the best way ✔)
   1. **Pros:** considering the foreground probability of each pixel in an instance, the algorithm is well-informed
   2. **Cons:** slightly slower than 1 & 2 but after careful design and simple tests I believe it handles segmentation/superpixels at a scale of 100k instance in minutes

#### Example Usage

As a standalone widget it not only helps reduce unnecessary computation but also can be flexibly used between different steps. For example, the following image shows how an instance connected to a false positive would be deleted if we simple use GASP followed by method 3:

![image](https://github.com/hci-unihd/plant-seg/assets/17722010/da73d545-0093-4f90-a020-0bf43534b404)

To have a perfect segmentation, users can apply a method 3 foreground filter before and after GASP like this:

Starting the a watershed output:

![image](https://github.com/hci-unihd/plant-seg/assets/17722010/f4525b21-319f-4e24-bd89-d94ccdcb85d1)

Apply the new filter:

![image](https://github.com/hci-unihd/plant-seg/assets/17722010/06164049-4540-4199-8728-ae93d13169cb)

Run GASP:

![image](https://github.com/hci-unihd/plant-seg/assets/17722010/b74c2b3b-7c95-4272-b28a-912a2ed332fe)

Apply my new filter again:

![image](https://github.com/hci-unihd/plant-seg/assets/17722010/d4a6a3b5-94cb-4f73-8594-9043265c37c6)
