### PR TITLE
Dev Env: Add BioImage.IO Core dependency and fix CUDA installation

### DIFF
--- a/docs/chapters/getting_started/contributing.md
+++ b/docs/chapters/getting_started/contributing.md
@@ -1,0 +1,18 @@
+# Contribute to PlantSeg
+
+PlantSeg is an open-source project and we welcome contributions from the community. There are many ways to contribute, from writing tutorials or blog posts, improving the documentation, submitting bug reports and feature requests or writing code which can be incorporated into PlantSeg itself.
+
+## Getting Started
+
+To set up the development environment, run:
+
+```bash
+mamba env create -f environment-dev.yml
+conda activate plant-seg-dev
+```
+
+To install PlantSeg in development mode, run:
+
+```bash
+pip install -e . --no-deps
+```

--- a/environment-dev.yaml
+++ b/environment-dev.yaml
@@ -15,10 +15,12 @@ dependencies:
   - vigra
   - cudnn
   - pytorch
+  - torchvision
   - pytorch-cuda=12.1
+  - cuda-version=12.3
   - python-elf
   - pyqt
   - napari
   - python-graphviz
-  - bioimageio.core
+  - bioimageio.core>=0.6.1
 # then `pip install -e .`

--- a/environment-dev.yaml
+++ b/environment-dev.yaml
@@ -20,4 +20,5 @@ dependencies:
   - pyqt
   - napari
   - python-graphviz
+  - bioimageio.core
 # then `pip install -e .`


### PR DESCRIPTION
1. Use `cuda-version=12.3` to avoid `mamba` adding `cudatoolkit` (11.1) into the environment, fix #228 
2. Add bioimageio.core to dev environment to allow alternative inference engine. PlantSeg inference and bioimageio.core inference are separately and successfully tested.