### PR TITLE
Type Fix: `np.array` is not a type, change to `np.ndarray`

### DIFF
--- a/docs/chapters/python_api/cnn_predictions.md
+++ b/docs/chapters/python_api/cnn_predictions.md
@@ -5,7 +5,7 @@ In this section we will describe how to use the PlantSeg CNN Predictions workflo
 ## API-Reference: [plantseg.predictions.functional.predictions](https://github.com/hci-unihd/plant-seg/blob/master/plantseg/predictions/functional/predictions.py)
 ### ***unet_predictions***
 ```python
-def unet_predictions(raw: np.array,
+def unet_predictions(raw: np.ndarray,
                      model_name: str,
                      patch: Tuple[int, int, int] = (80, 160, 160),
                      stride: Union[str, Tuple[int, int, int]] = 'Accurate (slowest)',
@@ -13,12 +13,12 @@ def unet_predictions(raw: np.array,
                      version: str = 'best',
                      model_update: bool = False,
                      mirror_padding: Tuple[int, int, int] = (16, 32, 32),
-                     disable_tqdm: bool = False) -> np.array:
+                     disable_tqdm: bool = False) -> np.ndarray:
     """
     Predict boundaries predictions from raw data using a 3D U-Net model.
 
     Args:
-        raw (np.array): raw data, must be a 3D array of shape (Z, Y, X) normalized between 0 and 1.
+        raw (np.ndarray): raw data, must be a 3D array of shape (Z, Y, X) normalized between 0 and 1.
         model_name (str): name of the model to use. A complete list of available models can be found here:
         patch (tuple[int, int, int], optional): patch size to use for prediction. Defaults to (80, 160, 160).
         stride (Union[str, tuple[int, int, int]], optional): stride to use for prediction.
@@ -32,7 +32,7 @@ def unet_predictions(raw: np.array,
         disable_tqdm (bool, optional): if True will disable tqdm progress bar. Defaults to False.
 
     Returns:
-        np.array: predictions, 3D array of shape (Z, Y, X) with values between 0 and 1.
+        np.ndarray: predictions, 3D array of shape (Z, Y, X) with values between 0 and 1.
 
     """
 

--- a/docs/chapters/python_api/segmentation.md
+++ b/docs/chapters/python_api/segmentation.md
@@ -5,7 +5,7 @@ In this section we will describe how to use the PlantSeg segmentation workflows 
 ## API-Reference: [plantseg.predictions.functional.segmentation](https://github.com/hci-unihd/plant-seg/blob/master/plantseg/segmentation/functional/segmentation.py)
 * ***dt_watershed***
 ```python
-def dt_watershed(boundary_pmaps: np.array,
+def dt_watershed(boundary_pmaps: np.ndarray,
                  threshold: float = 0.5,
                  sigma_seeds: float = 1.,
                  stacked: bool = False,
@@ -15,7 +15,7 @@ def dt_watershed(boundary_pmaps: np.array,
                  pixel_pitch: tuple[int, ...] = None,
                  apply_nonmax_suppression: bool = False,
                  n_threads: int = None,
-                 mask: np.array = None) -> np.array:
+                 mask: np.ndarray = None) -> np.ndarray:
     """ Wrapper around elf.distance_transform_watershed
     Args:
         boundary_pmaps (np.ndarray): input height map.
@@ -41,12 +41,12 @@ def dt_watershed(boundary_pmaps: np.array,
 https://github.com/hci-unihd/plant-seg/blob/de397694f523f142d67a38d5611acefd03e33137/plantseg/segmentation/functional/segmentation.py#L23-L122
 * ***gasp***
 ```python
-def gasp(boundary_pmaps: np.array,
-         superpixels: np.array = None,
+def gasp(boundary_pmaps: np.ndarray,
+         superpixels: np.ndarray = None,
          gasp_linkage_criteria: str = 'average',
          beta: float = 0.5,
          post_minsize: int = 100,
-         n_threads: int = 6) -> np.array:
+         n_threads: int = 6) -> np.ndarray:
     """
     Implementation of the GASP algorithm for segmentation from affinities.
     Args:
@@ -66,11 +66,11 @@ def gasp(boundary_pmaps: np.array,
 
 * ***mutex_ws***
 ```python
-def mutex_ws(boundary_pmaps: np.array,
-             superpixels: np.array = None,
+def mutex_ws(boundary_pmaps: np.ndarray,
+             superpixels: np.ndarray = None,
              beta: float = 0.5,
              post_minsize: int = 100,
-             n_threads: int = 6) -> np.array:
+             n_threads: int = 6) -> np.ndarray:
     """
     Wrapper around gasp with mutex_watershed as linkage criteria.
     Args:
@@ -90,10 +90,10 @@ def mutex_ws(boundary_pmaps: np.array,
 
 * ***multicut***
 ```python
-def multicut(boundary_pmaps: np.array,
-             superpixels: np.array,
+def multicut(boundary_pmaps: np.ndarray,
+             superpixels: np.ndarray,
              beta: float = 0.5,
-             post_minsize: int = 50) -> np.array:
+             post_minsize: int = 50) -> np.ndarray:
 
     """
     Multicut segmentation from boundary predictions.
@@ -112,16 +112,16 @@ def multicut(boundary_pmaps: np.array,
 
 * ***lifted_multicut_from_nuclei_segmentation***
 ```python
-def lifted_multicut_from_nuclei_segmentation(boundary_pmaps: np.array,
-                                             nuclei_seg: np.array,
-                                             superpixels: np.array,
+def lifted_multicut_from_nuclei_segmentation(boundary_pmaps: np.ndarray,
+                                             nuclei_seg: np.ndarray,
+                                             superpixels: np.ndarray,
                                              beta: float = 0.5,
-                                             post_minsize: int = 50) -> np.array:
+                                             post_minsize: int = 50) -> np.ndarray:
     """
     Lifted Multicut segmentation from boundary predictions and nuclei segmentation.
     Args:
         boundary_pmaps (np.ndarray): cell boundary predictions, 3D array of shape (Z, Y, X) with values between 0 and 1.
-        nuclei_seg (np.array): Nuclei segmentation. Must have the same shape as boundary_pmaps.
+        nuclei_seg (np.ndarray): Nuclei segmentation. Must have the same shape as boundary_pmaps.
         superpixels (np.ndarray): superpixel segmentation. Must have the same shape as boundary_pmaps.
         beta (float): beta parameter for the Multicut. A small value will steer the segmentation towards
         under-segmentation. While a high-value bias the segmentation towards the over-segmentation. (default: 0.5)

--- a/plantseg/dataprocessing/dataprocessing.py
+++ b/plantseg/dataprocessing/dataprocessing.py
@@ -52,7 +52,7 @@ class DataPostProcessing3D(GenericPipelineStep):
         # count processed images
         self.img_count = 0
 
-    def process(self, image: np.array) -> np.array:
+    def process(self, image: np.ndarray) -> np.ndarray:
         gui_logger.info("Postprocessing files...")
 
         if self.output_shapes is not None:
@@ -117,7 +117,7 @@ class DataPreProcessing3D(GenericPipelineStep):
             self.filter = _no_filter
             self.filter_param = 0
 
-    def process(self, image: np.array) -> np.array:
+    def process(self, image: np.ndarray) -> np.ndarray:
         gui_logger.info(f"Preprocessing files...")
         if self.crop is not None:
             gui_logger.info(f"Cropping input image to: {self.crop}")

--- a/plantseg/dataprocessing/functional/advanced_dataprocessing.py
+++ b/plantseg/dataprocessing/functional/advanced_dataprocessing.py
@@ -8,7 +8,7 @@ from skimage.filters import gaussian
 from skimage.segmentation import watershed, relabel_sequential
 from skimage.measure import regionprops
 
-def get_bbox(mask: np.array, pixel_toll: int = 0) -> tuple[tuple, int, int, int]:
+def get_bbox(mask: np.ndarray, pixel_toll: int = 0) -> tuple[tuple, int, int, int]:
     """
     returns the bounding box around a binary mask
     """
@@ -21,7 +21,7 @@ def get_bbox(mask: np.array, pixel_toll: int = 0) -> tuple[tuple, int, int, int]
     return (slice(z_min, z_max), slice(x_min, x_max), slice(y_min, y_max)), z_min, x_min, y_min
 
 
-def get_quantile_mask(counts: np.array, quantile: tuple[float, float] = (0.2, 0.99)) -> np.array:
+def get_quantile_mask(counts: np.ndarray, quantile: tuple[float, float] = (0.2, 0.99)) -> np.ndarray:
     """
     filters counts by quantiles
     """
@@ -32,7 +32,7 @@ def get_quantile_mask(counts: np.array, quantile: tuple[float, float] = (0.2, 0.
 
 
 @numba.njit(parallel=True)
-def numba_find_overlaps(cell_seg: np.array, n_seg: np.array) -> tuple[np.array, np.array, np.array]:
+def numba_find_overlaps(cell_seg: np.ndarray, n_seg: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """
     given a cell_seg: cell segmentation and a n_seg: nuclei segmentation
     returns: cell_sizes, nuclei_sizes, pixel overlap
@@ -60,9 +60,9 @@ def numba_find_overlaps(cell_seg: np.array, n_seg: np.array) -> tuple[np.array, 
     return cell_counts, n_counts, overlap_counts
 
 
-def find_potential_under_seg(nuclei_counts: np.array,
-                             cell_counts: np.array,
-                             intersection_counts: np.array,
+def find_potential_under_seg(nuclei_counts: np.ndarray,
+                             cell_counts: np.ndarray,
+                             intersection_counts: np.ndarray,
                              threshold: float = 0.9,
                              quantiles_clip: tuple[float, float] = (0.2, 0.99)) -> dict:
     """
@@ -89,8 +89,8 @@ def find_potential_under_seg(nuclei_counts: np.array,
     return cell_assigment
 
 
-def find_potential_over_seg(nuclei_counts: np.array,
-                            intersection_counts: np.array,
+def find_potential_over_seg(nuclei_counts: np.ndarray,
+                            intersection_counts: np.ndarray,
                             threshold: float = 0.3) -> dict:
     """
     returns for each nucleus idx a dict containing the overlap profile between said nucleus and the segmentation
@@ -116,10 +116,10 @@ def find_potential_over_seg(nuclei_counts: np.array,
     return nuclei_assigment
 
 
-def split_from_seeds(segmentation: np.array,
-                     boundary_pmap: np.array,
-                     seeds: np.array,
-                     all_idx: list[int]) -> np.array:
+def split_from_seeds(segmentation: np.ndarray,
+                     boundary_pmap: np.ndarray,
+                     seeds: np.ndarray,
+                     all_idx: list[int]) -> np.ndarray:
     """
     Split a segmentation using seeds watershed
     """
@@ -145,11 +145,11 @@ def split_from_seeds(segmentation: np.array,
     return c_segmentation
 
 
-def fix_under_segmentation(segmentation: np.array,
-                           nuclei_segmentation: np.array,
-                           boundary_pmap: np.array,
+def fix_under_segmentation(segmentation: np.ndarray,
+                           nuclei_segmentation: np.ndarray,
+                           boundary_pmap: np.ndarray,
                            cell_assignments: dict,
-                           cell_idx: Optional[list[int]] = None) -> np.array:
+                           cell_idx: Optional[list[int]] = None) -> np.ndarray:
     """
     this function attempts to fix cell under segmentation in the cells by splitting cells with multiple nuclei
     """
@@ -166,9 +166,9 @@ def fix_under_segmentation(segmentation: np.array,
     return _segmentation
 
 
-def fix_over_segmentation(segmentation: np.array,
+def fix_over_segmentation(segmentation: np.ndarray,
                           nuclei_assignments: dict,
-                          nuclei_idx: Optional[list[int]] = None) -> np.array:
+                          nuclei_idx: Optional[list[int]] = None) -> np.ndarray:
     """
     this function attempts to fix cell over segmentation by merging cells that splits in two a nucleus
     """
@@ -183,12 +183,12 @@ def fix_over_segmentation(segmentation: np.array,
     return _segmentation
 
 
-def fix_over_under_segmentation_from_nuclei(cell_seg: np.array,
-                                            nuclei_seg: np.array,
+def fix_over_under_segmentation_from_nuclei(cell_seg: np.ndarray,
+                                            nuclei_seg: np.ndarray,
                                             threshold_merge: float = 0.33,
                                             threshold_split: float = 0.66,
                                             quantiles_nuclei: tuple[float, float] = (0.3, 0.99),
-                                            boundary: Optional[np.array] = None) -> np.array:
+                                            boundary: Optional[np.ndarray] = None) -> np.ndarray:
     """
     This function attempts to fix cell under and over segmentation, given a trusted nuclei segmentation of the
     same image.
@@ -196,8 +196,8 @@ def fix_over_under_segmentation_from_nuclei(cell_seg: np.array,
     - To fix cell over segmentation, it will try to merge cells that splits in two a nucleus
 
     Args:
-        cell_seg (np.array): numpy array containing the cell segmentation
-        nuclei_seg (np.array): numpy array containing the nuclei segmentation
+        cell_seg (np.ndarray): numpy array containing the cell segmentation
+        nuclei_seg (np.ndarray): numpy array containing the nuclei segmentation
         threshold_merge (float, optional): percentage of the nucleus overlapping each cell segment.
             If the overlap is smaller than the defined threshold, the script will not merge the two cells.
             Defaults to 0.33.
@@ -206,10 +206,10 @@ def fix_over_under_segmentation_from_nuclei(cell_seg: np.array,
             Defaults to 0.66.
         quantiles_nuclei (tuple[float, float], optional): Remove nuclei too small or too large according to
             their quantiles. Defaults to (0.3, 0.99).
-        boundary (Optional[np.array], optional): Optional numpy array containing the boundary signal or,
+        boundary (Optional[np.ndarray], optional): Optional numpy array containing the boundary signal or,
             better, a boundary pmap. Defaults to None.
     Returns:
-        np.array: The new cell segmentation
+        np.ndarray: The new cell segmentation
     """
 
     # measure the overlap between cell and nuclei 1st time
@@ -237,9 +237,9 @@ def fix_over_under_segmentation_from_nuclei(cell_seg: np.array,
     return _cell_seg
 
 
-def remove_false_positives_by_foreground_probability(segmentation: np.array,
-                                                     foreground: np.array,
-                                                     threshold: float) -> np.array:
+def remove_false_positives_by_foreground_probability(segmentation: np.ndarray,
+                                                     foreground: np.ndarray,
+                                                     threshold: float) -> np.ndarray:
     """
     Remove false positive regions in a segmentation based on a foreground probability map in a smart way.
     If the mean(an instance * its own probability region) < threshold, it is removed.

--- a/plantseg/dataprocessing/functional/dataprocessing.py
+++ b/plantseg/dataprocessing/functional/dataprocessing.py
@@ -23,10 +23,10 @@ def compute_scaling_voxelsize(input_voxel_size: list[float, float, float],
     return output_voxel_size
 
 
-def scale_image_to_voxelsize(image: np.array,
+def scale_image_to_voxelsize(image: np.ndarray,
                              input_voxel_size: list[float, float, float],
                              output_voxel_size: list[float, float, float],
-                             order: int = 0) -> np.array:
+                             order: int = 0) -> np.ndarray:
     """
     scale an image from a given voxel size
     """
@@ -34,7 +34,7 @@ def scale_image_to_voxelsize(image: np.array,
     return image_rescale(image, factor, order=order)
 
 
-def image_rescale(image: np.array, factor: list[float, float, float], order: int) -> np.array:
+def image_rescale(image: np.ndarray, factor: list[float, float, float], order: int) -> np.ndarray:
     """
     scale an image from a given scaling factor
     """
@@ -44,7 +44,7 @@ def image_rescale(image: np.array, factor: list[float, float, float], order: int
         return zoom(image, zoom=factor, order=order)
 
 
-def image_median(image: np.array, radius: int) -> np.array:
+def image_median(image: np.ndarray, radius: int) -> np.ndarray:
     """
     apply median smoothing on an image
     """
@@ -56,7 +56,7 @@ def image_median(image: np.array, radius: int) -> np.array:
         return median(image, ball(radius))
 
 
-def image_gaussian_smoothing(image: np.array, sigma: float) -> np.array:
+def image_gaussian_smoothing(image: np.ndarray, sigma: float) -> np.ndarray:
     """
     apply gaussian smoothing on an image
     """
@@ -66,7 +66,7 @@ def image_gaussian_smoothing(image: np.array, sigma: float) -> np.array:
     return gaussianSmoothing(image, sigma)
 
 
-def image_crop(image: np.array, crop_str: str) -> np.array:
+def image_crop(image: np.ndarray, crop_str: str) -> np.array:
     """
     crop image from a crop string like [:, 10:30:, 10:20]
     """
@@ -77,7 +77,7 @@ def image_crop(image: np.array, crop_str: str) -> np.array:
     return image[slices]
 
 
-def fix_input_shape(data: np.array, ndim=3) -> np.array:
+def fix_input_shape(data: np.ndarray, ndim=3) -> np.array:
     assert ndim in [3, 4]
     if ndim == 3:
         return fix_input_shape_to_3D(data)
@@ -85,7 +85,7 @@ def fix_input_shape(data: np.array, ndim=3) -> np.array:
         return fix_input_shape_to_4D(data)
 
 
-def fix_input_shape_to_3D(data: np.array) -> np.array:
+def fix_input_shape_to_3D(data: np.ndarray) -> np.array:
     """
     fix array ndim to be always 3
     """
@@ -102,7 +102,7 @@ def fix_input_shape_to_3D(data: np.array) -> np.array:
         raise RuntimeError(f"Expected input data to be 2d, 3d or 4d, but got {data.ndim}d input")
 
 
-def fix_input_shape_to_4D(data: np.array) -> np.array:
+def fix_input_shape_to_4D(data: np.ndarray) -> np.array:
     """
     Fix array ndim to be 4 and return it in (C x Z x Y x X) e.g. 2 x 1 x 512 x 512
 
@@ -121,7 +121,7 @@ def fix_input_shape_to_4D(data: np.array) -> np.array:
         raise RuntimeError(f"Expected input data to be 3d or 4d, but got {data.ndim}d input")
 
 
-def normalize_01(data: np.array) -> np.array:
+def normalize_01(data: np.ndarray) -> np.array:
     """
     normalize a numpy array between 0 and 1
     """

--- a/plantseg/dataprocessing/functional/labelprocessing.py
+++ b/plantseg/dataprocessing/functional/labelprocessing.py
@@ -2,7 +2,7 @@ import numpy as np
 from skimage import measure
 
 
-def relabel_segmentation(segmentation_image: np.array) -> np.array:
+def relabel_segmentation(segmentation_image: np.ndarray) -> np.array:
     """
     Relabel contiguously a segmentation image, non-touching instances with same id will be relabeled differently.
     To be noted that measure.label is different from ndimage.label
@@ -16,7 +16,7 @@ def relabel_segmentation(segmentation_image: np.array) -> np.array:
     return measure.label(segmentation_image)
 
 
-def set_background_to_value(segmentation_image: np.array, value: int = 0) -> np.array:
+def set_background_to_value(segmentation_image: np.ndarray, value: int = 0) -> np.array:
     """
     Set the largest segment (usually this is the background but not always) to a certain value
 

--- a/plantseg/io/h5.py
+++ b/plantseg/io/h5.py
@@ -27,7 +27,7 @@ def read_h5_voxel_size(f, h5key: str) -> list[float, float, float]:
 
 def _find_input_key(h5_file) -> str:
     f"""
-    returns the first matching key in H5_KEYS or only one dataset is found the key to that dataset 
+    returns the first matching key in H5_KEYS or only one dataset is found the key to that dataset
     """
     found_datasets = []
 
@@ -84,7 +84,7 @@ def load_h5(path: str,
 
 
 def create_h5(path: str,
-              stack: np.array,
+              stack: np.ndarray,
               key: str,
               voxel_size: tuple[float, float, float] = (1.0, 1.0, 1.0),
               mode: str = 'a') -> None:

--- a/plantseg/io/tiff.py
+++ b/plantseg/io/tiff.py
@@ -143,7 +143,7 @@ def load_tiff(path: str, info_only: bool = False) -> Union[tuple, tuple[np.array
     return file, infos
 
 
-def create_tiff(path: str, stack: np.array, voxel_size: list[float, float, float], voxel_size_unit: str = 'um') -> None:
+def create_tiff(path: str, stack: np.ndarray, voxel_size: list[float, float, float], voxel_size_unit: str = 'um') -> None:
     """
     Create a tiff file from a numpy array
 

--- a/plantseg/io/zarr.py
+++ b/plantseg/io/zarr.py
@@ -35,7 +35,7 @@ def read_zarr_voxel_size(f, zarrkey: str) -> list[float, float, float]:
 
 def _find_input_key(zarr_file) -> str:
     f"""
-    returns the first matching key in ZARR_KEYS or only one dataset is found the key to that dataset 
+    returns the first matching key in ZARR_KEYS or only one dataset is found the key to that dataset
     """
     found_datasets = []
 
@@ -92,7 +92,7 @@ def load_zarr(path: str,
 
 
 def create_zarr(path: str,
-                stack: np.array,
+                stack: np.ndarray,
                 key: str,
                 voxel_size: tuple[float, float, float] = (1.0, 1.0, 1.0),
                 mode: str = 'a') -> None:

--- a/plantseg/predictions/functional/predictions.py
+++ b/plantseg/predictions/functional/predictions.py
@@ -12,7 +12,7 @@ from plantseg.predictions.functional.slice_builder import SliceBuilder
 from plantseg.predictions.functional.utils import get_model_config, get_patch_halo, get_stride_shape
 
 def unet_predictions(
-    raw: np.array,
+    raw: np.ndarray,
     model_name: str,
     patch: Tuple[int, int, int] = (80, 160, 160),
     single_batch_mode: bool = True,
@@ -21,14 +21,14 @@ def unet_predictions(
     disable_tqdm: bool = False,
     handle_multichannel: bool = False,
     **kwargs
-) -> np.array:
+) -> np.ndarray:
     """Generate predictions from raw data using a specified 3D U-Net model.
 
     This function handles both single and multi-channel outputs from the model,
     returning appropriately shaped arrays based on the output channel configuration.
 
     Args:
-        raw (np.array): Raw input data as a 3D array of shape (Z, Y, X).
+        raw (np.ndarray): Raw input data as a 3D array of shape (Z, Y, X).
         model_name (str): The name of the model to use.
         patch (Tuple[int, int, int], optional): Patch size for prediction. Defaults to (80, 160, 160).
         single_batch_mode (bool, optional): Whether to use a single batch for prediction. Defaults to True.
@@ -38,7 +38,7 @@ def unet_predictions(
         handle_multichannel (bool, optional): If True, handles multi-channel output properly. Defaults to False.
 
     Returns:
-        np.array: The predicted boundaries as a 3D (Z, Y, X) or 4D (C, Z, Y, X) array, normalized between 0 and 1.
+        np.ndarray: The predicted boundaries as a 3D (Z, Y, X) or 4D (C, Z, Y, X) array, normalized between 0 and 1.
     """
     model, model_config, model_path = get_model_config(model_name, model_update=model_update)
     state = torch.load(model_path, map_location='cpu')

--- a/plantseg/segmentation/functional/segmentation.py
+++ b/plantseg/segmentation/functional/segmentation.py
@@ -19,7 +19,7 @@ except ImportError:
     sitk_installed = False
 
 
-def dt_watershed(boundary_pmaps: np.array,
+def dt_watershed(boundary_pmaps: np.ndarray,
                  threshold: float = 0.5,
                  sigma_seeds: float = 1.,
                  stacked: bool = False,
@@ -29,7 +29,7 @@ def dt_watershed(boundary_pmaps: np.array,
                  pixel_pitch: tuple[int, ...] = None,
                  apply_nonmax_suppression: bool = False,
                  n_threads: int = None,
-                 mask: np.array = None) -> np.array:
+                 mask: np.ndarray = None) -> np.array:
     """ Wrapper around elf.distance_transform_watershed
 
     Args:
@@ -71,8 +71,8 @@ def dt_watershed(boundary_pmaps: np.array,
     return ws
 
 
-def gasp(boundary_pmaps: np.array,
-         superpixels: np.array = None,
+def gasp(boundary_pmaps: np.ndarray,
+         superpixels: np.ndarray = None,
          gasp_linkage_criteria: str = 'average',
          beta: float = 0.5,
          post_minsize: int = 100,
@@ -137,8 +137,8 @@ def gasp(boundary_pmaps: np.array,
     return segmentation
 
 
-def mutex_ws(boundary_pmaps: np.array,
-             superpixels: np.array = None,
+def mutex_ws(boundary_pmaps: np.ndarray,
+             superpixels: np.ndarray = None,
              beta: float = 0.5,
              post_minsize: int = 100,
              n_threads: int = 6) -> np.array:
@@ -166,8 +166,8 @@ def mutex_ws(boundary_pmaps: np.array,
                 n_threads=n_threads)
 
 
-def multicut(boundary_pmaps: np.array,
-             superpixels: np.array,
+def multicut(boundary_pmaps: np.ndarray,
+             superpixels: np.ndarray,
              beta: float = 0.5,
              post_minsize: int = 50) -> np.array:
 
@@ -207,9 +207,9 @@ def multicut(boundary_pmaps: np.array,
     return segmentation
 
 
-def lifted_multicut_from_nuclei_pmaps(boundary_pmaps: np.array,
-                                      nuclei_pmaps: np.array,
-                                      superpixels: np.array,
+def lifted_multicut_from_nuclei_pmaps(boundary_pmaps: np.ndarray,
+                                      nuclei_pmaps: np.ndarray,
+                                      superpixels: np.ndarray,
                                       beta: float = 0.5,
                                       post_minsize: int = 50) -> np.array:
     """
@@ -255,9 +255,9 @@ def lifted_multicut_from_nuclei_pmaps(boundary_pmaps: np.array,
     return segmentation
 
 
-def lifted_multicut_from_nuclei_segmentation(boundary_pmaps: np.array,
-                                             nuclei_seg: np.array,
-                                             superpixels: np.array,
+def lifted_multicut_from_nuclei_segmentation(boundary_pmaps: np.ndarray,
+                                             nuclei_seg: np.ndarray,
+                                             superpixels: np.ndarray,
                                              beta: float = 0.5,
                                              post_minsize: int = 50) -> np.array:
     """
@@ -299,7 +299,7 @@ def lifted_multicut_from_nuclei_segmentation(boundary_pmaps: np.array,
     return segmentation
 
 
-def simple_itk_watershed(boundary_pmaps: np.array,
+def simple_itk_watershed(boundary_pmaps: np.ndarray,
                          threshold: float = 0.5,
                          sigma: float = 1.0,
                          minsize: int = 100) -> np.array:
@@ -337,8 +337,8 @@ def simple_itk_watershed(boundary_pmaps: np.array,
     return segmentation
 
 
-def simple_itk_watershed_from_markers(boundary_pmaps: np.array,
-                                      seeds: np.array):
+def simple_itk_watershed_from_markers(boundary_pmaps: np.ndarray,
+                                      seeds: np.ndarray):
     if not sitk_installed:
         raise ValueError('please install sitk before running this process')
 


### PR DESCRIPTION
Interestingly, `np.ndarray` has been used correctly in a few docstrings whose functions are using `np.array`.