### PR TITLE
Headless: Handle multi-channel prediction output and add docs

### DIFF
--- a/docs/chapters/getting_started/installation.md
+++ b/docs/chapters/getting_started/installation.md
@@ -90,7 +90,12 @@ Ultimately you may download this repo and install it from source for the latest 
 
 ## Optional dependencies
 
-*(not fully tested on Windows)*
+If you want to use the headless mode of PlantSeg, you need to install `dask[distributed]`:
+
+```bash
+conda activate plant-seg
+mamba install dask distributed
+```
 
 Some types of compressed tiff files require an additional package to be load correctly (e.g.: Zlib, ZSTD, LZMA, ...).
 To run PlantSeg on those stacks, you need to install `imagecodecs`.

--- a/docs/chapters/getting_started/troubleshooting.md
+++ b/docs/chapters/getting_started/troubleshooting.md
@@ -1,109 +1,80 @@
-# Troubleshooting  <!-- omit in toc -->
+# Troubleshooting <!-- omit in toc -->
 
-- [`Could not load library libcudnn_ops_infer.so.8.`](#could-not-load-library-libcudnn_ops_inferso8)
-- [`NVIDIA driver on your system is too old` or `Torch not compiled with CUDA enabled`](#nvidia-driver-on-your-system-is-too-old-or-torch-not-compiled-with-cuda-enabled)
-- [`RuntimeError: key : KEY_NAME is missing, plant-seg requires KEY_NAME to run`](#runtimeerror-key--key_name-is-missing-plant-seg-requires-key_name-to-run)
-- [`cannot import name 'lifted_problem_from_probabilities'`](#cannot-import-name-lifted_problem_from_probabilities)
-- [Other issues](#other-issues)
+This section provides solutions to common issues you might encounter while using PlantSeg. Click on a problem to jump to its specific solution.
+
+* [Problems with `--headless` and `dask[distributed]`](#problems-with---headless-and-daskdistributed)
+* [Could not load library `libcudnn_ops_infer.so.8`](#could-not-load-library-libcudnn_ops_inferso8)
+* [Missing configuration key errors](#missing-configuration-key-errors)
+* [Cannot import `lifted_problem_from_probabilities`](#cannot-import-lifted_problem_from_probabilities)
+* [Other issues](#other-issues)
 
 ----
 
-#### `Could not load library libcudnn_ops_infer.so.8.`
+## Problems with `--headless` and `dask[distributed]`
 
-If you stumble in the following error message:
+If you encounter the following error:
+
+```plaintext
+ImportError: dask.distributed is not installed.
 ```
+
+Please install `dask[distributed]` to enable headless mode in PlantSeg. Run the following commands in your terminal:
+
+```bash
+mamba activate plant-seg
+mamba install -c pytorch -c nvidia -c conda-forge dask distributed
+```
+
+## Could not load library `libcudnn_ops_infer.so.8`
+
+If you encounter this error:
+
+```plaintext
 Could not load library libcudnn_ops_infer.so.8. Error: libcudnn_ops_infer.so.8: cannot open shared object file: No such file or directory
 ```
 
-Just install `cudnn` by running:
-```
-$ mamba install -c conda-forge cudnn
+Resolve this by installing `cudnn` using the following command:
+
+```bash
+mamba install -c conda-forge cudnn
 ```
 
 ----
 
-#### `NVIDIA driver on your system is too old` or `Torch not compiled with CUDA enabled`
+## Missing configuration key errors
 
-If you stumble in the following error message:
-```
-AssertionError:
-The NVIDIA driver on your system is too old (found version xxxx).
-Please update your GPU driver by downloading and installing a new
-version from the URL: http://www.nvidia.com/Download/index.aspx
-Alternatively, go to: http://pytorch.org to install
-a PyTorch version that has been compiled with your version
-of the CUDA driver.
-```
-or:
-```
-    raise AssertionError("Torch not compiled with CUDA enabled")
-AssertionError: Torch not compiled with CUDA enabled
-```
-It means that your cuda installation does not match the default in plantseg.
-You can check your current cuda version by typing in the terminal
-```
-cat /usr/local/cuda/version.txt
-```
-Then you can re-install the pytorch version compatible with your cuda by activating your `plant-seg` environment:
-```
-conda activate plant-seg
-```
-and
-```
-conda install -c pytorch torchvision cudatoolkit=<YOU_CUDA_VERSION> pytorch
-```
-e.g. for cuda 9.2
-```
-conda install -c pytorch torchvision cudatoolkit=9.2 pytorch
-```
+If you encounter a `RuntimeError` about a missing key, such as:
 
-Alternatively one can create the `plant-seg` environment from scratch and ensuring the correct version of cuda/pytorch, by:
-```
-conda create -n plant-seg -c lcerrone -c abailoni -c cpape -c conda-forge cudatoolkit=<YOU_CUDA_VERSION> plantseg
-```
-
-----
-
-#### `RuntimeError: key : KEY_NAME is missing, plant-seg requires KEY_NAME to run`
-
-If you use plantseg from the GUI and you receive an error similar to:
-```
-RuntimeError: key : 'crop_volume' is missing, plant-seg requires 'crop_volume' to run
-```
-(or a similar message for any of the other keys)
-It might be that the last session configuration file got corrupted or is outdated.
-You should be able to solve it by removing the corrupted file `config_gui_last.yaml`.
-
-If you have a standard installation of plantseg, you can remove it by executing on the terminal:
-```
-$ rm ~/.plantseg_models/configs/config_gui_last.yaml
-```
-
-If you use plantseg from the command line, and you receive an error similar to:
-```
+```plaintext
 RuntimeError: key : 'crop_volume' is missing, plant-seg requires 'crop_volume' to run
 ```
 
-Please make sure that your configuration has the correct formatting and contains all required keys.
-An updated example can be found inside the directory `examples`, in this repository.
+This usually means the session configuration file is corrupted or outdated. To fix this:
+
+```bash
+rm ~/.plantseg_models/configs/config_gui_last.yaml
+```
+
+Ensure your configuration file is properly formatted and includes all required keys. Example configurations can be found in the `examples` directory of this repository.
 
 ----
 
-#### `cannot import name 'lifted_problem_from_probabilities'`
+## Cannot import `lifted_problem_from_probabilities`
 
-If when trying to execute the Lifted Multicut pipeline you receive an error like:
-```
-'cannot import name 'lifted_problem_from_probabilities' from 'elf.segmentation.features''
-```
-The solution is to re-install [elf](https://github.com/constantinpape/elf) via
-```
+If you receive an error related to importing from `elf.segmentation.features`, reinstall [elf](https://github.com/constantinpape/elf):
+
+```bash
 conda install -c conda-forge python-elf
 ```
 
 ----
 
-#### Other issues
+## Other issues
 
-* PlantSeg is under active development, so it may happen that the models/configuration files saved in `~/.plantseg_modes`
-are outdated. In case of errors related to loading the configuration file, please close the PlantSeg app,
-remove `~/.plantseg_models` directory and try again.
+PlantSeg is actively developed, and sometimes model or configuration files saved in `~/.plantseg_models` may become outdated. If you encounter errors related to configuration loading:
+
+1. Close the PlantSeg application.
+2. Delete the `~/.plantsep_models` directory.
+3. Restart the application and try again.
+
+These steps should help resolve any issues and enhance your experience with PlantSeg.

--- a/docs/chapters/plantseg_interactive_napari/headless_batch_processing.md
+++ b/docs/chapters/plantseg_interactive_napari/headless_batch_processing.md
@@ -1,4 +1,12 @@
 # Headless Batch Processing
 
-!!! warning "Documentation in Progress"
-    This page is under development.
+When image(s) are exported from PlantSeg Napari, a workflow file, e.g. `workflow.pkl`, describing the processing steps is saved alongside the exported images. This workflow can be used to process more images with the same parameters in each step of the workflow, in the headless mode.
+
+To run the headless mode, use:
+
+```bash
+plantseg --headless PATH_TO_WORKFLOW
+```
+
+!!! warning "Network Prediction with 2-channel Output"
+    If the network used in the workflow has a 2-channel output, no other steps can be performed after the network prediction step. The only supported PlantSeg Napari workflow for headless 2-channel-output prediction is open file -> network prediction -> save file.

--- a/plantseg/viewer/headless.py
+++ b/plantseg/viewer/headless.py
@@ -1,7 +1,6 @@
 import multiprocessing
 import time
 from pathlib import Path
-from typing import List, Tuple
 
 from dask.distributed import LocalCluster, Client
 from magicgui import magicgui
@@ -16,9 +15,8 @@ ALL_DEVICES_HEADLESS = ALL_DEVICES + ALL_GPUS
 MAX_WORKERS = len(ALL_CUDA_DEVICES) if ALL_CUDA_DEVICES else multiprocessing.cpu_count()
 
 
-def parse_input_paths(inputs: List[str], path_suffix: str = '_path') -> Tuple[List[str], str]:
+def parse_input_paths(inputs: list[str], path_suffix: str = '_path') -> tuple[list[str], str]:
     input_paths = [_input for _input in inputs if _input.endswith(path_suffix)]
-    input_hints = tuple([Path] * len(input_paths))
     input_names = '/'.join(input.replace(path_suffix, '') for input in input_paths)
     return input_paths, input_names
 
@@ -42,7 +40,7 @@ def run_workflow_headless(path: Path):
               scheduler={'label': 'Scheduler',
                          'choices': ['multiprocessing', 'threaded']},
               call_button='Run PlantSeg')
-    def run(list_inputs: List[Tuple[Path, ...]],
+    def run(list_inputs: list[tuple[Path]],  # -> ListEdit; magicgui cannot handle `...` in type hints
             out_directory: Path = Path.home(),
             device: str = ALL_DEVICES_HEADLESS[0],
             num_workers: int = MAX_WORKERS,
@@ -68,4 +66,5 @@ def run_workflow_headless(path: Path):
             client.gather(results)
             print(f'Process ended in: {time.time() - start_time:.2f}s')
 
+    run.native.setWindowTitle('PlantSeg Headless')
     run.show(run=True)

--- a/plantseg/viewer/headless.py
+++ b/plantseg/viewer/headless.py
@@ -66,5 +66,7 @@ def run_workflow_headless(path: Path):
             client.gather(results)
             print(f'Process ended in: {time.time() - start_time:.2f}s')
 
-    run.native.setWindowTitle('PlantSeg Headless')
+    if hasattr(run.native, 'setWindowTitle'):
+        run.native.setWindowTitle('PlantSeg Headless')
+
     run.show(run=True)

--- a/plantseg/viewer/widget/predictions.py
+++ b/plantseg/viewer/widget/predictions.py
@@ -84,18 +84,22 @@ def widget_unet_predictions(viewer: Viewer,
     layer_kwargs['metadata']['pmap'] = True  # this is used to warn the user that the layer is a pmap
 
     layer_type = 'image'
-    step_kwargs = dict(model_name=model_name, patch=patch_size, patch_halo=patch_halo, single_batch_mode=single_patch)
+    step_kwargs = dict(model_name=model_name,
+                       patch=patch_size,
+                       patch_halo=patch_halo,
+                       single_batch_mode=single_patch,
+                       handle_multichannel=True)
 
     return start_prediction_process(unet_predictions_wrapper,
                                     runtime_kwargs={'raw': image.data,
-                                                    'device': device,
-                                                    'handle_multichannel': True},
+                                                    'device': device},
                                     statics_kwargs=step_kwargs,
                                     out_name=out_name,
                                     input_keys=inputs_names,
                                     layer_kwarg=layer_kwargs,
                                     layer_type=layer_type,
                                     step_name='UNet Predictions',
+                                    skip_dag=False,
                                     viewer=viewer,
                                     widgets_to_update=[widget_agglomeration.image,
                                                        widget_lifted_multicut.image,
@@ -359,4 +363,3 @@ if TOO_MANY_WIDGES:
         _widget.hide()
 
 # widget_extra_pred_manager.enabled=TOO_MANY_WIDGES
-

--- a/plantseg/viewer/widget/utils.py
+++ b/plantseg/viewer/widget/utils.py
@@ -1,7 +1,7 @@
 import timeit
 from concurrent.futures import Future
 from functools import partial
-from typing import Callable, Tuple
+from typing import Callable, Optional, Tuple
 
 from magicgui.widgets import Widget
 from napari import Viewer
@@ -76,11 +76,13 @@ def start_prediction_process(func: Callable,
                             out_name: str,
                             input_keys: Tuple[str, ...],
                             layer_kwarg: dict,
-                            layer_type: str = 'image',
-                            step_name: str = '',
-                            skip_dag: bool = False,
-                            viewer: Viewer = None,
-                            widgets_to_update: list = None) -> Future:
+                            layer_type: str,
+                            step_name: str,
+                            skip_dag: bool,
+                            viewer: Viewer,
+                            widgets_to_update: Optional[list] = None) -> Future:
+    assert out_name == layer_kwarg['name'], 'out_name and layer_kwarg name should be the same'
+
     runtime_kwargs.update(statics_kwargs)
     thread_func = thread_worker(partial(func, **runtime_kwargs))
     future = Future()
@@ -90,22 +92,31 @@ def start_prediction_process(func: Callable,
         timer = timeit.default_timer() - timer_start
         napari_formatted_logging(f'Widget {step_name} computation complete in {timer:.2f}s', thread=step_name)
         _func = func if not skip_dag else identity
-        dag_manager.add_step(_func, input_keys=input_keys,
-                             output_key=out_name,
-                             static_params=statics_kwargs,
-                             step_name=step_name)
-        if result.ndim == 4:  # then we have a 2-channel output
+
+        if result.ndim == 4:  # then we have a 2-channel output, output is always CZYX or ZYX
             pmap_layers = []
             for i, pmap in enumerate(result):
                 temp_layer_kwarg = layer_kwarg.copy()
                 temp_layer_kwarg['name'] = layer_kwarg['name'] + f'_{i}'
                 pmap_layers.append((pmap, temp_layer_kwarg, layer_type))
+                dag_manager.add_step(_func, input_keys=input_keys,
+                                     output_key=temp_layer_kwarg['name'],
+                                     static_params=statics_kwargs,
+                                     step_name=step_name)
             result = pmap_layers
-            
+
             # Only widget_unet_predictions() invokes and handles 4D UNet output for now, but headless mode can also invoke this part, thus warn:
-            napari_formatted_logging(f'Widget {step_name}: Headless mode is not supported for 2-channel output predictions', thread=step_name, level='warning')
+            napari_formatted_logging(f'Widget {step_name}: Headless mode is partially supported for 2-channel output predictions.\n'
+                                     'Supported headless workflow: open file -> 2-channel prediction -> save file.\n'
+                                     'More steps following 2-channel prediction are not supported in headless mode.',
+                                     thread=step_name, level='warning')
         else:  # then we have a 1-channel output
             result = result, layer_kwarg, layer_type
+            dag_manager.add_step(_func, input_keys=input_keys,
+                                 output_key=layer_kwarg['name'],
+                                 static_params=statics_kwargs,
+                                 step_name=step_name)
+
         future.set_result(result)
 
         if viewer is not None and widgets_to_update is not None:


### PR DESCRIPTION
With this PR, I make `--headless` mode handle a special case: a workflow of "open file -> multi-channel network prediction -> export file". A workflow combined with any post-processing step may still fail. Multi-channel output from networks were not handled until #184. Back then, `--headless` mode with DAG was not considered as an important use case, because 

1. I made `--config` mode available for processing multi-channel network output;
2. Lorenzo will refactor headless mode with a new design.
