### PR TITLE
fix: rescale to voxelsize workflow

### DIFF
--- a/plantseg/tasks/dataprocessing_tasks.py
+++ b/plantseg/tasks/dataprocessing_tasks.py
@@ -203,7 +203,10 @@ def image_rescale_to_shape_task(
 
 @task_tracker
 def image_rescale_to_voxel_size_task(
-    image: PlantSegImage, new_voxel_size: VoxelSize, order: int = 0
+    image: PlantSegImage,
+    new_voxels_size: tuple[float, float, float],
+    new_unit: str,
+    order: int = 0,
 ) -> PlantSegImage:
     """Rescale an image to a new voxel size.
 
@@ -215,6 +218,7 @@ def image_rescale_to_voxel_size_task(
         order (int): order of the interpolation
 
     """
+    new_voxel_size = VoxelSize(voxels_size=new_voxels_size, unit=new_unit)
     spatial_scaling_factor = image.voxel_size.scalefactor_from_voxelsize(new_voxel_size)
 
     if image.image_layout == ImageLayout.YX:
@@ -227,6 +231,8 @@ def image_rescale_to_voxel_size_task(
         scaling_factor = (1.0, *spatial_scaling_factor)
     elif image.image_layout == ImageLayout.ZCYX:
         scaling_factor = (spatial_scaling_factor[0], 1.0, *spatial_scaling_factor[1:])
+    else:
+        raise ValueError(f"Unknown image layout {image.image_layout}")
 
     out_data = image_rescale(image.get_data(), scaling_factor, order=order)
     new_image = image.derive_new(

--- a/plantseg/viewer_napari/widgets/dataprocessing.py
+++ b/plantseg/viewer_napari/widgets/dataprocessing.py
@@ -348,7 +348,8 @@ def widget_rescaling(
         image_rescale_to_voxel_size_task,
         task_kwargs={
             "image": ps_image,
-            "new_voxel_size": out_voxel_size,
+            "new_voxels_size": out_voxel_size.voxels_size,
+            "new_unit": out_voxel_size.unit,
             "order": order,
         },
         widgets_to_update=widgets_to_update,

--- a/plantseg/workflow_gui/widgets.py
+++ b/plantseg/workflow_gui/widgets.py
@@ -112,6 +112,7 @@ class Workflow_widgets:
 
         with open(config_path, "r") as f:
             self.config = yaml.safe_load(f)
+            logger.debug(f"LOADED:\n{self.config}")
         self.show_config()
 
     def fill_config_c(self):
@@ -401,10 +402,10 @@ class Task_node:
 
         elif self.func == "image_rescale_to_voxel_size_task":
             x, y, z, unit = (
-                FloatSpinBox(value=self.parameters["new_voxel_size"]["voxels_size"][0]),
-                FloatSpinBox(value=self.parameters["new_voxel_size"]["voxels_size"][1]),
-                FloatSpinBox(value=self.parameters["new_voxel_size"]["voxels_size"][2]),
-                LineEdit(value=self.parameters["new_voxel_size"]["unit"]),
+                FloatSpinBox(value=self.parameters["new_voxels_size"][0]),
+                FloatSpinBox(value=self.parameters["new_voxels_size"][1]),
+                FloatSpinBox(value=self.parameters["new_voxels_size"][2]),
+                LineEdit(value=self.parameters["new_unit"]),
             )
             w = Container(
                 label=label,
@@ -414,10 +415,8 @@ class Task_node:
             )
             self.changing_fields[self.id] = lambda: {
                 "parameters": {
-                    "new_voxel_size": {
-                        "unit": unit.value,
-                        "voxels_size": [x.value, y.value, z.value],
-                    }
+                    "new_unit": unit.value,
+                    "new_voxels_size": [x.value, y.value, z.value],
                 }
             }
             return Container(widgets=[w])

--- a/tests/resources/test_workflow.yaml
+++ b/tests/resources/test_workflow.yaml
@@ -74,12 +74,11 @@ list_tasks:
   outputs:
   - sample_ovule_raw_set_voxel_size_smoothed_rescaled_1297c6cd-c2b7-4893-92b1-b34aaffc2c18
   parameters:
-    new_voxel_size:
-      unit: um
-      voxels_size:
-      - 0.15
-      - 0.1
-      - 0.1
+    new_unit: um
+    new_voxels_size:
+    - 0.15
+    - 0.1
+    - 0.1
     order: 0
   skip: false
 - func: unet_prediction_task


### PR DESCRIPTION
`image_rescale_to_voxel_size_task` in workflows was broken. It expected a `VoxelSize`, but only ever received a dict from the loaded yaml workflow.

Fixed for now by not attempting to serialize the `VoxelSize` but instead save and load the dict.

fixes #447