### PR TITLE
fix: `PlantSegImage` `voxel_size` to Napari `scale`

### DIFF
--- a/plantseg/core/image.py
+++ b/plantseg/core/image.py
@@ -518,13 +518,13 @@ class PlantSegImage:
         The scale is equal to the voxel size in each spatial dimension and 1 in other channels.
         """
         if self.image_layout == ImageLayout.YX:
-            return (self.voxel_size.x, self.voxel_size.y)
+            return (self.voxel_size.y, self.voxel_size.x)
         elif self.image_layout == ImageLayout.ZYX:
-            return (self.voxel_size.z, self.voxel_size.x, self.voxel_size.y)
+            return (self.voxel_size.z, self.voxel_size.y, self.voxel_size.x)
         elif self.image_layout == ImageLayout.CYX:
-            return (1.0, self.voxel_size.x, self.voxel_size.y)
+            return (1.0, self.voxel_size.y, self.voxel_size.x)
         elif self.image_layout == ImageLayout.CZYX:
-            return (1.0, self.voxel_size.z, self.voxel_size.x, self.voxel_size.y)
+            return (1.0, self.voxel_size.z, self.voxel_size.y, self.voxel_size.x)
         elif self.image_layout == ImageLayout.ZCYX:
             raise ValueError(
                 f"Image layout {self.image_layout} not supported, should have been converted to CZYX"


### PR DESCRIPTION
This PR fixes a long-standing bug where the x and y voxel sizes were swapped during conversion from `PlantSegImage` to Napari layers. The issue went unnoticed until now because the x and y voxel sizes are usually identical.

Before fix:

<img width="4356" height="1694" alt="CleanShot 2025-10-28 at 16 30 19@2x" src="https://github.com/user-attachments/assets/c637b306-416a-474b-90db-c04573598d3a" />

After fix:

<img width="4334" height="1694" alt="CleanShot 2025-10-28 at 16 28 17@2x" src="https://github.com/user-attachments/assets/a2760af0-1c0c-4848-8cec-b7aa35541f27" />
