### PR TITLE
fix: model downloads

### DIFF
--- a/tests/core/test_zoo.py
+++ b/tests/core/test_zoo.py
@@ -31,6 +31,7 @@ class TestPlantSegModelZoo:
         model, _, model_path = model_zoo.get_model_by_name(
             model_name, model_update=True
         )
+        assert model_path.exists()
         state = torch.load(model_path, map_location="cpu", weights_only=True)
         model.load_state_dict(state)
         model.eval()


### PR DESCRIPTION
If only the config files of a model were already downloaded, the model itself could not be downloaded anymore, causing an error.

fixes #525 