### PR TITLE
fix: pin versions

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -53,10 +53,10 @@ requirements:
     - tensorboard==2.20.0
     - tifffile==2026.3.3
     - vigra==1.12.2
+    - trimesh==4.11.4
+    - numpy==2.4.3
     - zarr==3.1.5
-    - trimesh==4.11.3
     - zmesh==1.8.0
-    - numpy==2.4.2
 
 test:
   imports:

--- a/docs/chapters/getting_started/contributing.md
+++ b/docs/chapters/getting_started/contributing.md
@@ -85,10 +85,12 @@ Before releasing, you might want to update those pins:
 bash update_deps.sh
 ```
 
-This updates the environment `panseg-dev` and its `yaml` file.
-Using this updated `environment-dev.yaml` file, update the following files:
+This updates the environment `panseg-dev` and its `yaml` file.  
+It also updates the `environment.yaml` by matching its content against the now
+updated packages in `environment-dev.yaml`.
 
-* `environment.yaml`
+Using this updated `environment.yaml` file, **manually** update the following files:
+
 * `conda-recipe/meta.yaml`
 
 To release, run the github workflow `release`, then manually publish to `conda-forge`.

--- a/environment-dev.yaml
+++ b/environment-dev.yaml
@@ -2,6 +2,8 @@ name: panseg-dev
 channels:
   - conda-forge
 dependencies:
+  - python[version='>=3.11']
+  - pip
   - bioimageio.core==0.9.6
   - bioimageio.spec==0.5.7.4
   - bump-my-version
@@ -13,7 +15,6 @@ dependencies:
   - mkdocs-material
   - mkdocstrings-python
   - napari==0.6.6
-  - pip
   - pre-commit
   - pydantic==2.12.5
   - pyside6==6.10.2
@@ -23,7 +24,6 @@ dependencies:
   - pytest-qt
   - python-elf==0.7.4
   - python-graphviz==0.21
-  - python[version='>=3.11']
   - pytorch==2.10.0
   - pyyaml==6.0.3
   - qt-material==2.14
@@ -34,10 +34,10 @@ dependencies:
   - tensorboard==2.20.0
   - tifffile==2026.3.3
   - vigra==1.12.2
+  - trimesh==4.11.4
+  - numpy==2.4.3
   - zarr==3.1.5
-  - trimesh==4.11.3
   - zmesh==1.8.0
-  - numpy==2.4.2
   - pip:
       - markdown-exec
       - -e .

--- a/environment.yaml
+++ b/environment.yaml
@@ -2,28 +2,28 @@ name: panseg
 channels:
   - conda-forge
 dependencies:
+  - python[version='>=3.11']
+  - pip
   - bioimageio.core==0.9.6
   - bioimageio.spec==0.5.7.4
-  - h5py=3.15.1
-  - napari=0.6.6
-  - pip
+  - h5py==3.15.1
+  - napari==0.6.6
   - pydantic==2.12.5
   - pyside6==6.10.2
-  - python-elf=0.7.4
-  - python-graphviz=0.21
-  - python[version='>=3.11']
+  - python-elf==0.7.4
+  - python-graphviz==0.21
   - pytorch==2.10.0
-  - pyyaml=6.0.3
-  - qt-material=2.14
-  - qtpy=2.4.3
-  - requests=2.32.5
+  - pyyaml==6.0.3
+  - qt-material==2.14
+  - qtpy==2.4.3
+  - requests==2.32.5
   - scikit-image==0.26.0
-  - tensorboard=2.20.0
+  - tensorboard==2.20.0
   - tifffile==2026.3.3
-  - vigra=1.12.2
-  - zarr=3.1.5
-  - trimesh==4.11.3
-  - zmesh=1.8.0
-  - numpy=2.4
+  - vigra==1.12.2
+  - trimesh==4.11.4
+  - numpy==2.4.3
+  - zarr==3.1.5
+  - zmesh==1.8.0
   - pip:
       - -e .

--- a/update_deps.sh
+++ b/update_deps.sh
@@ -1,12 +1,125 @@
 #!/bin/bash
 
+# This script updates the panseg-dev conda environment and its yaml file.
+# Only pinned packages stay pinned.
+# The `environment.yaml` file gets updated from the dev environment.
+# Both files can contain non-pinned packages.
+# Please don't forget to update the conda-recipe/meta.yaml
+
+ENV_FILE="environment.yaml"
+DEV_ENV_FILE="environment-dev.yaml"
+
 conda update -n panseg-dev --all
-conda export --from-history --no-builds -n panseg-dev -f environment-dev.yaml
+conda export --from-history --no-builds -n panseg-dev -f $DEV_ENV_FILE
 # remove the prefix line
-head -n -1 environment-dev.yaml >temp_env.yaml && mv temp_env.yaml environment-dev.yaml
+head -n -1 $DEV_ENV_FILE >temp_env.yaml && mv temp_env.yaml $DEV_ENV_FILE
 
 cat >>environment-dev.yaml <<'EOF'
   - pip:
       - markdown-exec
       - -e .
 EOF
+
+TEMP_ENV="tmp"
+
+# Create associative arrays to store package information
+declare -A dev_packages
+
+# Extract packages from environment-dev.yaml into associative arrays
+echo "DEBUG: Reading packages from $DEV_ENV_FILE" >&2
+while IFS= read -r line; do
+  # Check if we've reached the pip section
+  if [[ "$line" =~ ^[[:space:]]*-[[:space:]]pip: ]]; then
+    echo "DEBUG: Reached pip section in dev environment" >&2
+    break
+  fi
+
+  # Check if we're in the dependencies section
+  if [[ "$line" =~ ^[[:space:]]*dependencies:[[:space:]]*$ ]]; then
+    echo "DEBUG: Entering dependencies section in dev environment" >&2
+    in_deps=true
+    continue
+  fi
+
+  # Skip lines that aren't in dependencies or are pip section
+  if [[ ! "$line" =~ ^[[:space:]]*- ]] || [[ ! "${in_deps:-false}" == true ]]; then
+    continue
+  fi
+
+  # Extract package name from line
+  package_line="${line#*-[[:space:] ]}"
+  package_line="${package_line%%[[:space:]]*}"
+
+  # Extract just the package name part (before =, <, >)
+  pkg_name=""
+  if [[ "$package_line" =~ ^([^=<>]+) ]]; then
+    pkg_name="${BASH_REMATCH[1]}"
+  fi
+
+  # Only process if we have a valid package name
+  if [[ -n "$pkg_name" ]]; then
+    # Store the full package line
+    dev_packages["$pkg_name"]="$line"
+    echo "DEBUG: Stored package $pkg_name from dev environment" >&2
+  fi
+done <"$DEV_ENV_FILE"
+
+# Process environment.yaml and update matching packages
+echo "DEBUG: Processing main environment file $ENV_FILE" >&2
+{
+  in_deps=false
+  in_pip=false
+
+  while IFS= read -r line; do
+    # Check if we've reached the pip section
+    if [[ "$line" =~ ^[[:space:]]*-[[:space:]]pip: ]]; then
+      echo "DEBUG: Reached pip section in main environment" >&2
+      in_pip=true
+      echo "$line"
+      continue
+    fi
+
+    # Check if we're entering dependencies section
+    if [[ "$line" =~ ^[[:space:]]*dependencies:[[:space:]]*$ ]]; then
+      echo "DEBUG: Entering dependencies section in main environment" >&2
+      in_deps=true
+      echo "$line"
+      continue
+    fi
+
+    # If we're in pip section, just print the line
+    if [[ "${in_pip:-false}" == true ]]; then
+      echo "$line"
+      continue
+    fi
+
+    # Check if we're in dependencies and have a package line
+    if [[ "${in_deps:-false}" == true ]] && [[ "$line" =~ ^[[:space:]]*- ]]; then
+      # Extract package name from line
+      package_line="${line#*-[[:space:] ]}"
+      package_line="${package_line%%[[:space:]]*}"
+
+      # Extract just the package name part (before =, <, >)
+      pkg_name=""
+      if [[ "$package_line" =~ ^([^=<>]+) ]]; then
+        pkg_name="${BASH_REMATCH[1]}"
+      fi
+
+      # If this matches a package from environment-dev.yaml, use the environment-dev.yaml version
+      if [[ -n "$pkg_name" ]] && [[ -n "${dev_packages[$pkg_name]}" ]]; then
+        echo "DEBUG: Updating package $pkg_name from dev version: ${dev_packages[$pkg_name]}" >&2
+        echo "${dev_packages[$pkg_name]}"
+      else
+        echo "$line"
+      fi
+    else
+      echo "$line"
+    fi
+  done <"$ENV_FILE"
+} >"$TEMP_ENV"
+
+# Replace original file
+echo "DEBUG: Replacing original file with updated content" >&2
+mv "$TEMP_ENV" "$ENV_FILE"
+
+echo "Sync complete!"


### PR DESCRIPTION
Adds script to automatically update the version pins of `environment-dev.yaml`

Other places with version pins still need to be updated manually from this file.