### PR TITLE
fix: bbox offset (#542)

### DIFF
--- a/plantseg/functionals/dataprocessing/advanced_dataprocessing.py
+++ b/plantseg/functionals/dataprocessing/advanced_dataprocessing.py
@@ -8,6 +8,8 @@ from skimage.filters import gaussian
 from skimage.measure import regionprops
 from skimage.segmentation import relabel_sequential, watershed
 
+from plantseg.functionals.proofreading.utils import get_bboxes
+
 logger = logging.getLogger(__name__)
 
 
@@ -16,6 +18,7 @@ def get_bbox(
 ) -> tuple[tuple[slice, slice, slice], int, int, int]:
     """
     Returns the bounding box around a binary mask with optional padding.
+    Bounding boxes are half-open intervals [lower,upper)
 
     Args:
         mask (np.ndarray): Binary mask to calculate the bounding box.
@@ -24,28 +27,9 @@ def get_bbox(
     Returns:
         tuple[tuple[slice, slice, slice], int, int, int]: Bounding box slices and minimum coordinates.
     """
-    coords = np.nonzero(mask)
 
-    z_min, z_max = (
-        max(coords[0].min() - pixel_tolerance, 0),
-        min(coords[0].max() + pixel_tolerance, mask.shape[0]),
-    )
-    z_max = max(z_max, z_min + 1)  # Ensure non-zero size
-    x_min, x_max = (
-        max(coords[1].min() - pixel_tolerance, 0),
-        min(coords[1].max() + pixel_tolerance, mask.shape[1]),
-    )
-    y_min, y_max = (
-        max(coords[2].min() - pixel_tolerance, 0),
-        min(coords[2].max() + pixel_tolerance, mask.shape[2]),
-    )
-
-    return (
-        (slice(z_min, z_max), slice(x_min, x_max), slice(y_min, y_max)),
-        z_min,
-        x_min,
-        y_min,
-    )
+    bboxes_d = get_bboxes(mask, (pixel_tolerance) * 3)
+    return tuple([slice(a[0], a[1], None) for a in zip(*bboxes_d[1])])
 
 
 def get_quantile_mask(
@@ -202,7 +186,7 @@ def split_from_seeds(
     """
     segmentation_copy = copy.deepcopy(segmentation)
     mask = np.isin(segmentation_copy, all_idx)
-    bbox, _, _, _ = get_bbox(mask)
+    bbox = get_bbox(mask)
 
     cropped_boundary_pmap = boundary_pmap[bbox]
     cropped_seeds = seeds[bbox]

--- a/plantseg/functionals/proofreading/split_merge_tools.py
+++ b/plantseg/functionals/proofreading/split_merge_tools.py
@@ -8,7 +8,13 @@ from plantseg.functionals.proofreading.utils import get_bboxes, get_idx_slice
 logger = logging.getLogger(__name__)
 
 
-def _merge_from_seeds(segmentation, region_slice, region_bbox, bboxes, all_idx):
+def _merge_from_seeds(
+    segmentation: np.ndarray,
+    region_slice: tuple[slice],
+    region_bbox: np.ndarray,
+    bboxes: dict[int, np.ndarray],
+    all_idx: np.ndarray,
+) -> tuple[np.ndarray, tuple[slice], dict[int, np.ndarray]]:
     region_segmentation = segmentation[region_slice]
 
     mask = [region_segmentation == idx for idx in all_idx]
@@ -18,20 +24,23 @@ def _merge_from_seeds(segmentation, region_slice, region_bbox, bboxes, all_idx):
     mask = np.logical_or.reduce(mask)
     region_segmentation[mask] = new_label
     bboxes[new_label] = region_bbox
+    for idx in all_idx:
+        if idx != new_label:
+            bboxes.pop(idx)
     logger.info("Merge complete")
     return region_segmentation, region_slice, bboxes
 
 
 def _split_from_seed(
-    segmentation,
-    seeds_list,
-    region_slice,
-    all_idx,
-    offsets,
-    bboxes,
-    image,
-    seeds_values,
-    max_label,
+    segmentation: np.ndarray,
+    seeds_list: tuple[np.ndarray],
+    region_slice: tuple[slice],
+    all_idx: np.ndarray,
+    offsets: np.ndarray,
+    bboxes: dict[int, np.ndarray],
+    image: np.ndarray,
+    seeds_values: np.ndarray,
+    max_label: int,
 ):
     local_seeds_list = [ls - of for ls, of in zip(seeds_list, offsets)]
 
@@ -60,7 +69,12 @@ def _split_from_seed(
 
 
 def split_merge_from_seeds(
-    seeds, segmentation, image, bboxes, max_label, correct_labels
+    seeds: np.ndarray,
+    segmentation: np.ndarray,
+    image: np.ndarray,
+    bboxes: dict[int, np.ndarray],
+    max_label: int,
+    correct_labels: set,
 ):
     # find seeds location ad label value
     seeds_list = np.nonzero(seeds)

--- a/plantseg/functionals/proofreading/utils.py
+++ b/plantseg/functionals/proofreading/utils.py
@@ -15,24 +15,24 @@ def _get_bboxes3D(segmentation, labels_idx):
     for z in range(shape[0]):
         for x in range(shape[1]):
             for y in range(shape[2]):
-                idx = segmentation[z, x, y]
-                if idx > 0:
-                    zmin, xmin, ymin = bboxes[idx][0]
-                    zmax, xmax, ymax = bboxes[idx][1]
+                value = segmentation[z, x, y]
+                if value > 0:
+                    zmin, xmin, ymin = bboxes[value][0]
+                    zmax, xmax, ymax = bboxes[value][1]
 
                     if z < zmin:
-                        bboxes[idx][0, 0] = z
+                        bboxes[value][0, 0] = z
                     if x < xmin:
-                        bboxes[idx][0, 1] = x
+                        bboxes[value][0, 1] = x
                     if y < ymin:
-                        bboxes[idx][0, 2] = y
+                        bboxes[value][0, 2] = y
 
-                    if z > zmax:
-                        bboxes[idx][1, 0] = z
-                    if x > xmax:
-                        bboxes[idx][1, 1] = x
-                    if y > ymax:
-                        bboxes[idx][1, 2] = y
+                    if z >= zmax:
+                        bboxes[value][1, 0] = z + 1
+                    if x >= xmax:
+                        bboxes[value][1, 1] = x + 1
+                    if y >= ymax:
+                        bboxes[value][1, 2] = y + 1
     return bboxes
 
 
@@ -47,20 +47,20 @@ def _get_bboxes2D(segmentation, labels_idx):
 
     for x in range(shape[0]):
         for y in range(shape[1]):
-            idx = segmentation[x, y]
-            if idx > 0:
-                xmin, ymin = bboxes[idx][0]
-                xmax, ymax = bboxes[idx][1]
+            value = segmentation[x, y]
+            if value > 0:
+                xmin, ymin = bboxes[value][0]
+                xmax, ymax = bboxes[value][1]
 
                 if x < xmin:
-                    bboxes[idx][0, 0] = x
+                    bboxes[value][0, 0] = x
                 if y < ymin:
-                    bboxes[idx][0, 1] = y
+                    bboxes[value][0, 1] = y
 
-                if x > xmax:
-                    bboxes[idx][1, 0] = x
-                if y > ymax:
-                    bboxes[idx][1, 1] = y
+                if x >= xmax:
+                    bboxes[value][1, 0] = x + 1
+                if y >= ymax:
+                    bboxes[value][1, 1] = y + 1
     return bboxes
 
 
@@ -76,6 +76,10 @@ def _get_bboxes(segmentation, labels_idx):
 
 
 def get_bboxes(segmentation, slack=(1, 3, 3)):
+    """Get the bounding boxes of all values in the segmentation
+
+    Bounding boxes are half-open intervals [lower, upper)
+    """
     segmentation = segmentation.astype("int64")
     labels_idx = np.unique(segmentation)
     bboxes = _get_bboxes(segmentation, labels_idx)
@@ -93,7 +97,16 @@ def get_bboxes(segmentation, slack=(1, 3, 3)):
     return bboxes_out
 
 
-def get_idx_slice(indices, bboxes_dict: dict):
+def get_idx_slice(
+    indices, bboxes_dict: dict
+) -> tuple[tuple[slice], np.ndarray, np.ndarray]:
+    """Merge bounding boxes to get a bigger bounding box
+
+    Returns:
+        tuple over all dimensions containing a slice
+        array containing the min and max coordinates
+        array containing the first dimension of the former array
+    """
     if isinstance(indices, int):
         indices = [indices]
 
@@ -103,4 +116,8 @@ def get_idx_slice(indices, bboxes_dict: dict):
     max_values = np.max(np.stack(list_max_values), axis=0)
     values = np.stack([min_values, max_values])
 
-    return tuple([slice(_min, _max) for _min, _max in zip(*values)]), values, min_values
+    return (
+        tuple([slice(_min, _max) for _min, _max in zip(*values)]),
+        values,
+        min_values,
+    )

--- a/plantseg/viewer_napari/widgets/proofreading.py
+++ b/plantseg/viewer_napari/widgets/proofreading.py
@@ -584,9 +584,9 @@ class ProofreadingHandler:
         Args:
             seg_slice (np.ndarray): The segmentation slice to update.
             region_slice (tuple[slice, ...]): The region slice to update in the viewer.
-            bbox (np.ndarray): The bounding box to update.
+            bbox (dict): The bounding box to update.
         """
-        self._state.bboxes = bbox
+        self.bboxes.update(bbox)
         update_region(
             data=seg_slice,
             layer_name=self.seg_layer_name,

--- a/tests/functionals/dataprocessing/test_advanced.py
+++ b/tests/functionals/dataprocessing/test_advanced.py
@@ -2,8 +2,19 @@ import numpy as np
 
 from plantseg.functionals.dataprocessing.advanced_dataprocessing import (
     fix_over_under_segmentation_from_nuclei,
+    get_bbox,
     remove_false_positives_by_foreground_probability,
 )
+from plantseg.functionals.proofreading.utils import get_bboxes as get_bboxes_proof
+
+
+def test_get_bbox_mask_slices():
+    mask = np.zeros((5, 5, 5), dtype=bool)
+    mask[0:2, 1:2, 2:3] = True
+    slices = get_bbox(mask, pixel_tolerance=0)
+    assert slices[0] == slice(0, 2, None)
+    assert slices[1] == slice(1, 2, None)
+    assert slices[2] == slice(2, 3, None)
 
 
 def test_remove_false_positives_by_foreground_probability():

--- a/tests/functionals/proofreading/test_split_merge.py
+++ b/tests/functionals/proofreading/test_split_merge.py
@@ -1,0 +1,487 @@
+import numpy as np
+
+from plantseg.functionals.proofreading.split_merge_tools import (
+    _merge_from_seeds,
+    _split_from_seed,
+    split_merge_from_seeds,
+)
+
+
+def test_merge_from_seeds_all_to_one():
+    """Test basic merging functionality"""
+    segmentation = np.array(
+        [
+            [[1, 2, 1], [2, 1, 2], [1, 2, 1]],
+            [[2, 1, 2], [1, 2, 1], [2, 1, 2]],
+            [[1, 2, 1], [2, 1, 2], [1, 2, 1]],
+        ]
+    )
+
+    region_slice = (slice(0, 3), slice(0, 3), slice(0, 3))
+    region_bbox = np.array([[0, 0, 0], [3, 3, 3]])
+
+    bboxes = {1: np.array([[0, 0, 0], [2, 2, 2]]), 2: np.array([[0, 0, 0], [2, 2, 2]])}
+
+    all_idx = np.array([1, 2])
+
+    result_seg, result_slice, result_bboxes = _merge_from_seeds(
+        segmentation, region_slice, region_bbox, bboxes, all_idx
+    )
+
+    assert result_seg.shape == segmentation.shape
+
+    expected_result = np.ones_like(segmentation)
+    np.testing.assert_array_equal(result_seg, expected_result)
+    assert all([rs == slice(0, 3, None) for rs in result_slice])
+
+    assert len(result_bboxes) == 1
+    assert np.all(result_bboxes[1] == np.array([[0, 0, 0], [3, 3, 3]]))
+
+
+def test_merge_from_seeds_with_other_label():
+    """Test merging when 0 is in the indices"""
+    # Create a simple 3D segmentation
+    segmentation = np.array(
+        [
+            [[0, 1, 0], [1, 0, 1], [0, 1, 0]],
+            [[1, 0, 1], [0, 1, 0], [3, 3, 1]],
+            [[0, 1, 0], [1, 0, 1], [3, 1, 0]],
+        ]
+    )
+
+    region_slice = (slice(0, 3), slice(0, 3), slice(0, 3))
+    region_bbox = np.array([[0, 0, 0], [3, 3, 3]])
+
+    bboxes = {
+        0: np.array([[0, 0, 0], [3, 3, 3]]),
+        1: np.array([[0, 0, 0], [3, 3, 3]]),
+        3: np.array([[1, 2, 0], [3, 3, 2]]),
+    }
+
+    all_idx = np.array([0, 1])
+
+    result_seg, result_slice, result_bboxes = _merge_from_seeds(
+        segmentation, region_slice, region_bbox, bboxes, all_idx
+    )
+
+    assert result_seg.shape == segmentation.shape
+
+    expected_result = np.zeros_like(segmentation)
+    expected_result[segmentation == 0] = 0
+    expected_result[segmentation == 1] = 0
+    expected_result[segmentation == 3] = 3
+
+    np.testing.assert_array_equal(result_seg, expected_result)
+    assert all([rs == slice(0, 3, None) for rs in result_slice])
+
+    # Check that bboxes was updated with the new label
+    assert np.array_equal(result_bboxes[0], region_bbox)
+    assert len(result_bboxes) == 2
+    assert np.all(result_bboxes[0] == np.array([[0, 0, 0], [3, 3, 3]]))
+    assert np.all(result_bboxes[3] == bboxes[3])
+
+
+def test_merge_from_seeds_single_label():
+    """Test merging with a single label"""
+    segmentation = np.array(
+        [
+            [[3, 3, 3], [3, 3, 3], [3, 3, 3]],
+            [[3, 3, 3], [3, 3, 3], [3, 3, 3]],
+            [[3, 3, 3], [3, 3, 3], [3, 3, 3]],
+        ]
+    )
+
+    region_slice = (slice(0, 3), slice(0, 3), slice(0, 3))
+    region_bbox = np.array([[0, 0, 0], [3, 3, 3]])
+
+    bboxes = {3: np.array([[0, 0, 0], [3, 3, 3]])}
+
+    all_idx = np.array([3])
+
+    result_seg, result_slice, result_bboxes = _merge_from_seeds(
+        segmentation, region_slice, region_bbox, bboxes, all_idx
+    )
+
+    assert result_seg.shape == segmentation.shape
+    np.testing.assert_array_equal(result_seg, segmentation)
+
+    assert 3 in result_bboxes
+    assert len(result_bboxes) == 1
+    assert np.array_equal(result_bboxes[3], region_bbox)
+
+
+def test_merge_from_seeds_2d():
+    """Test merging functionality with 2D segmentation"""
+    segmentation = np.array(
+        [
+            [1, 2, 1],
+            [2, 1, 2],
+            [1, 2, 1],
+        ]
+    )
+
+    region_slice = (slice(0, 3), slice(0, 3))
+    region_bbox = np.array([[0, 0], [2, 2]])
+
+    bboxes = {1: np.array([[0, 0], [2, 2]]), 2: np.array([[0, 0], [2, 2]])}
+
+    all_idx = np.array([1, 2])
+
+    result_seg, result_slice, result_bboxes = _merge_from_seeds(
+        segmentation, region_slice, region_bbox, bboxes, all_idx
+    )
+
+    assert result_seg.shape == segmentation.shape
+
+    expected_result = np.zeros_like(segmentation)
+    expected_result[segmentation == 1] = 1
+    expected_result[segmentation == 2] = 1
+    expected_result[(segmentation != 1) & (segmentation != 2)] = segmentation[
+        (segmentation != 1) & (segmentation != 2)
+    ]
+
+    np.testing.assert_array_equal(result_seg, expected_result)
+
+    assert 1 in result_bboxes
+    assert np.array_equal(result_bboxes[1], region_bbox)
+
+
+def test_split_from_seed_single_seed():
+    """Test splitting with one seed - should merge segments but leave others unchanged"""
+    segmentation = np.array(
+        [
+            [[1, 1, 2], [1, 1, 2], [2, 2, 2]],
+            [[1, 1, 2], [1, 1, 2], [2, 2, 2]],
+            [[1, 1, 2], [1, 1, 2], [2, 2, 2]],
+        ]
+    )
+
+    # Use explicit image data instead of random
+    image = np.array(
+        [
+            [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]],
+            [[0.2, 0.3, 0.4], [0.5, 0.6, 0.7], [0.8, 0.9, 0.1]],
+            [[0.3, 0.4, 0.5], [0.6, 0.7, 0.8], [0.9, 0.1, 0.2]],
+        ]
+    )
+
+    seeds_list = (
+        [0, 0, 0, 1, 1, 2],
+        [0, 1, 2, 0, 1, 2],
+        [0, 0, 0, 0, 0, 0],
+    )
+    seeds_values = np.array([1, 1, 1, 1, 1, 1])
+
+    region_slice = (slice(0, 3), slice(0, 3), slice(0, 3))
+    all_idx = np.array([1, 2])
+    offsets = np.array([0, 0, 0])
+    bboxes = {1: np.array([[0, 0, 0], [2, 2, 2]]), 2: np.array([[0, 0, 0], [2, 2, 2]])}
+    max_label = 2
+
+    result_seg, result_slice, result_bboxes = _split_from_seed(
+        segmentation,
+        seeds_list,
+        region_slice,
+        all_idx,
+        offsets,
+        bboxes,
+        image,
+        seeds_values,
+        max_label,
+    )
+
+    assert result_seg.shape == segmentation.shape
+
+    assert all([rs == slice(0, 3, None) for rs in result_slice])
+
+    assert len(result_bboxes) == 3
+
+
+def test_split_from_seed_two_seeds_same_segment():
+    """Test splitting with two seeds on the same segment"""
+    segmentation = np.array(
+        [
+            [[1, 1, 1], [1, 2, 2], [1, 2, 2]],
+            [[1, 1, 1], [1, 2, 2], [1, 2, 2]],
+            [[1, 1, 1], [1, 2, 2], [1, 2, 2]],
+        ]
+    )
+
+    # Use explicit image data instead of random
+    image = np.array(
+        [
+            [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]],
+            [[0.2, 0.3, 0.4], [0.5, 0.6, 0.7], [0.8, 0.9, 0.1]],
+            [[0.3, 0.4, 0.5], [0.6, 0.7, 0.8], [0.9, 0.1, 0.2]],
+        ]
+    )
+
+    seeds_list = (
+        [0, 0, 1, 1],
+        [0, 1, 0, 1],
+        [0, 0, 0, 0],
+    )
+    seeds_values = np.array([1, 1, 1, 1])  # All seeds have value 1
+
+    region_slice = (slice(0, 3), slice(0, 3), slice(0, 3))
+    all_idx = np.array([1, 2])
+    offsets = np.array([0, 0, 0])
+    bboxes = {1: np.array([[0, 0, 0], [2, 2, 2]]), 2: np.array([[0, 0, 0], [2, 2, 2]])}
+    max_label = 2
+
+    result_seg, result_slice, result_bboxes = _split_from_seed(
+        segmentation,
+        seeds_list,
+        region_slice,
+        all_idx,
+        offsets,
+        bboxes,
+        image,
+        seeds_values,
+        max_label,
+    )
+
+    assert result_seg.shape == segmentation.shape
+    assert all([rs == slice(0, 3, None) for rs in result_slice])
+    assert len(result_bboxes) == 3
+
+
+def test_split_from_seed_two_seeds_different_segments():
+    """Test splitting with two seeds on different segments"""
+    # Create a simple 3D segmentation
+    segmentation = np.array(
+        [
+            [[1, 1, 1], [2, 2, 2], [1, 1, 1]],
+            [[1, 1, 1], [2, 2, 2], [1, 1, 1]],
+            [[1, 1, 1], [2, 2, 2], [1, 1, 1]],
+        ]
+    )
+
+    # Create explicit image data instead of random
+    image = np.array(
+        [
+            [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]],
+            [[0.2, 0.3, 0.4], [0.5, 0.6, 0.7], [0.8, 0.9, 0.1]],
+            [[0.3, 0.4, 0.5], [0.6, 0.7, 0.8], [0.9, 0.1, 0.2]],
+        ]
+    )
+
+    # Define seeds for splitting - two seeds on segment 1 and one on segment 2
+    seeds_list = (
+        [0, 0, 1],
+        [0, 1, 1],
+        [0, 0, 0],
+    )
+    seeds_values = np.array([1, 1, 2])  # Seeds have values 1, 1, 2
+
+    region_slice = (slice(0, 3), slice(0, 3), slice(0, 3))
+    all_idx = np.array([1, 2])
+    offsets = np.array([0, 0, 0])
+    bboxes = {1: np.array([[0, 0, 0], [2, 2, 2]]), 2: np.array([[0, 0, 0], [2, 2, 2]])}
+    max_label = 2
+
+    result_seg, result_slice, result_bboxes = _split_from_seed(
+        segmentation,
+        seeds_list,
+        region_slice,
+        all_idx,
+        offsets,
+        bboxes,
+        image,
+        seeds_values,
+        max_label,
+    )
+
+    assert result_seg.shape == segmentation.shape
+    assert all([rs == slice(0, 3, None) for rs in result_slice])
+    assert len(result_bboxes) == 4
+
+
+def test_split_from_seed_with_zero_segmentation():
+    """Test splitting behavior with zero in segmentation"""
+    segmentation = np.array(
+        [
+            [[0, 1, 0], [1, 1, 1], [0, 1, 0]],
+            [[0, 1, 0], [1, 1, 1], [0, 1, 0]],
+            [[0, 1, 0], [1, 1, 1], [0, 1, 0]],
+        ]
+    )
+
+    image = np.array(
+        [
+            [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]],
+            [[0.2, 0.3, 0.4], [0.5, 0.6, 0.7], [0.8, 0.9, 0.1]],
+            [[0.3, 0.4, 0.5], [0.6, 0.7, 0.8], [0.9, 0.1, 0.2]],
+        ]
+    )
+
+    seeds_list = (
+        [0, 0, 1, 1],
+        [0, 1, 0, 1],
+        [0, 0, 0, 0],
+    )
+    seeds_values = np.array([1, 1, 1, 1])  # All seeds have value 1
+
+    region_slice = (slice(0, 3), slice(0, 3), slice(0, 3))
+    all_idx = np.array([0, 1])
+    offsets = np.array([0, 0, 0])
+    bboxes = {0: np.array([[0, 0, 0], [2, 2, 2]]), 1: np.array([[0, 0, 0], [2, 2, 2]])}
+    max_label = 1
+
+    result_seg, result_slice, result_bboxes = _split_from_seed(
+        segmentation,
+        seeds_list,
+        region_slice,
+        all_idx,
+        offsets,
+        bboxes,
+        image,
+        seeds_values,
+        max_label,
+    )
+
+    assert result_seg.shape == segmentation.shape
+    assert all([rs == slice(0, 3, None) for rs in result_slice])
+    assert len(result_bboxes) == 3
+
+
+def test_split_from_seed_preserves_unrelated_segments():
+    """Test that segments not in seeds_list remain unchanged"""
+    segmentation = np.array(
+        [
+            [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+            [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+            [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+        ]
+    )
+
+    image = np.array(
+        [
+            [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]],
+            [[0.2, 0.3, 0.4], [0.5, 0.6, 0.7], [0.8, 0.9, 0.1]],
+            [[0.3, 0.4, 0.5], [0.6, 0.7, 0.8], [0.9, 0.1, 0.2]],
+        ]
+    )
+
+    seeds_list = (
+        [0, 0, 1, 1],
+        [0, 1, 0, 1],
+        [0, 0, 0, 0],
+    )
+    seeds_values = np.array([1, 1, 1, 1])
+
+    region_slice = (slice(0, 3), slice(0, 3), slice(0, 3))
+    all_idx = np.array([1, 2])
+    offsets = np.array([0, 0, 0])
+    bboxes = {
+        1: np.array([[0, 0, 0], [2, 2, 2]]),
+        2: np.array([[0, 0, 0], [2, 2, 2]]),
+        3: np.array([[0, 0, 0], [2, 2, 2]]),
+    }
+    max_label = 3
+
+    result_seg, result_slice, result_bboxes = _split_from_seed(
+        segmentation,
+        seeds_list,
+        region_slice,
+        all_idx,
+        offsets,
+        bboxes,
+        image,
+        seeds_values,
+        max_label,
+    )
+
+    assert result_seg.shape == segmentation.shape
+    assert all([rs == slice(0, 3, None) for rs in result_slice])
+    assert len(result_bboxes) == 4
+
+
+def test_split_merge_from_seeds_mocked(mocker):
+    seeds = np.array(
+        [
+            [[0, 0, 0], [0, 1, 0], [0, 0, 0]],
+            [[0, 1, 0], [1, 1, 1], [0, 1, 0]],
+            [[0, 0, 0], [0, 1, 0], [0, 0, 0]],
+        ]
+    )
+
+    segmentation = np.array(
+        [
+            [[1, 1, 1], [1, 2, 1], [1, 1, 1]],
+            [[1, 2, 1], [2, 2, 2], [1, 2, 1]],
+            [[1, 1, 1], [1, 2, 1], [1, 1, 1]],
+        ]
+    )
+
+    image = np.array(
+        [
+            [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]],
+            [[0.2, 0.3, 0.4], [0.5, 0.6, 0.7], [0.8, 0.9, 0.1]],
+            [[0.3, 0.4, 0.5], [0.6, 0.7, 0.8], [0.9, 0.1, 0.2]],
+        ]
+    )
+
+    bboxes = {1: np.array([[0, 0, 0], [2, 2, 2]]), 2: np.array([[0, 0, 0], [2, 2, 2]])}
+    max_label = 2
+    correct_labels = set()
+
+    mock_merge_result = (
+        np.array(
+            [
+                [[1, 1, 1], [1, 1, 1], [1, 1, 1]],
+                [[1, 1, 1], [1, 1, 1], [1, 1, 1]],
+                [[1, 1, 1], [1, 1, 1], [1, 1, 1]],
+            ]
+        ),
+        (slice(0, 3), slice(0, 3), slice(0, 3)),
+        {1: np.array([[0, 0, 0], [3, 3, 3]])},
+    )
+
+    mock_split_result = (
+        np.array(
+            [
+                [[1, 1, 1], [1, 2, 1], [1, 1, 1]],
+                [[1, 2, 1], [2, 2, 2], [1, 2, 1]],
+                [[1, 1, 1], [1, 2, 1], [1, 1, 1]],
+            ]
+        ),
+        (slice(0, 3), slice(0, 3), slice(0, 3)),
+        {1: np.array([[0, 0, 0], [3, 3, 3]]), 2: np.array([[0, 0, 0], [3, 3, 3]])},
+    )
+
+    mock_merge = mocker.patch(
+        "plantseg.functionals.proofreading.split_merge_tools._merge_from_seeds",
+        return_value=mock_merge_result,
+    )
+
+    mock_split = mocker.patch(
+        "plantseg.functionals.proofreading.split_merge_tools._split_from_seed",
+        return_value=mock_split_result,
+    )
+
+    result_seg, result_slice, result_bboxes = split_merge_from_seeds(
+        seeds, segmentation, image, bboxes, max_label, correct_labels
+    )
+
+    mock_merge.assert_called_once()
+    mock_split.assert_not_called()
+
+    seeds_multi = np.array(
+        [
+            [[0, 0, 0], [0, 1, 0], [0, 0, 0]],
+            [[0, 1, 0], [1, 1, 1], [0, 1, 0]],
+            [[0, 0, 0], [0, 1, 0], [0, 0, 0]],
+        ]
+    )
+    seeds_multi[1, 1, 1] = 2
+
+    mock_merge.reset_mock()
+    mock_split.reset_mock()
+
+    result_seg2, result_slice2, result_bboxes2 = split_merge_from_seeds(
+        seeds_multi, segmentation, image, bboxes, max_label, correct_labels
+    )
+
+    mock_split.assert_called_once()
+    mock_merge.assert_not_called()

--- a/tests/widgets/test_proofreading.py
+++ b/tests/widgets/test_proofreading.py
@@ -376,13 +376,16 @@ class TestProofreadingHandler:
             _state=mocker.DEFAULT,
             seg_layer_name=mocker.DEFAULT,
             scale=mocker.DEFAULT,
+            bboxes=mocker.DEFAULT,
         )
         mocker.patch(
             "plantseg.viewer_napari.widgets.proofreading.update_region",
         )
+
         proof.update_after_proofreading(
             mocker.sentinel, mocker.sentinel, mocker.sentinel
         )
+        mocks["bboxes"].update.assert_called_once()
 
 
 def test_widget_clean_scribble(mocker, make_napari_viewer_proxy, napari_raw):
@@ -603,33 +606,17 @@ def test_widget_split_and_merge_from_scribbles(mocker, napari_raw, run_id, qtbot
     mock_split_merge.assert_not_called()
 
     mock_save = mocker.patch.object(handler, "save_to_history")
-    mocker.patch(
-        "plantseg.viewer_napari.widgets.proofreading.ProofreadingHandler.segmentation",
-        new_callable=mocker.PropertyMock,
-    )
-    mocker.patch(
-        "plantseg.viewer_napari.widgets.proofreading.ProofreadingHandler.seg_layer_name",
-        new_callable=mocker.PropertyMock,
-    )
-    mocker.patch(
-        "plantseg.viewer_napari.widgets.proofreading.ProofreadingHandler.scale",
-        new_callable=mocker.PropertyMock,
+    mocker.patch.multiple(
+        "plantseg.viewer_napari.widgets.proofreading.ProofreadingHandler",
+        segmentation=mocker.DEFAULT,
+        seg_layer_name=mocker.DEFAULT,
+        scale=mocker.DEFAULT,
+        bboxes=mocker.DEFAULT,
+        max_label=mocker.DEFAULT,
+        corrected_cells=mocker.DEFAULT,
     )
     mocker.patch(
         "plantseg.viewer_napari.widgets.proofreading.update_region",
-    )
-
-    mocker.patch(
-        "plantseg.viewer_napari.widgets.proofreading.ProofreadingHandler.bboxes",
-        new_callable=mocker.PropertyMock,
-    )
-    mocker.patch(
-        "plantseg.viewer_napari.widgets.proofreading.ProofreadingHandler.max_label",
-        new_callable=mocker.PropertyMock,
-    )
-    mocker.patch(
-        "plantseg.viewer_napari.widgets.proofreading.ProofreadingHandler.corrected_cells",
-        new_callable=mocker.PropertyMock,
     )
     scribble.sum.return_value = 5
     mock_split_merge.return_value = [mocker.sentinel] * 3

--- a/tests/widgets/test_proofreading_utils.py
+++ b/tests/widgets/test_proofreading_utils.py
@@ -20,8 +20,8 @@ def test_get_bboxes3D():
     bboxes = utils._get_bboxes3D(segmentation, typed_labels_idx)
 
     assert all([k in bboxes for k in labels_idx])
-    assert np.all(bboxes[1] == [[0, 0, 0], [1, 1, 1]])
-    assert np.all(bboxes[2] == [[3, 3, 3], [4, 5, 6]])
+    assert np.all(bboxes[1] == [[0, 0, 0], [2, 2, 2]])
+    assert np.all(bboxes[2] == [[3, 3, 3], [5, 6, 7]])
     assert np.all(bboxes[0] == [segmentation.shape, [0, 0, 0]])
 
 
@@ -36,8 +36,8 @@ def test_get_bboxes2D():
     bboxes = utils._get_bboxes2D(segmentation, typed_labels_idx)
 
     assert all([k in bboxes for k in labels_idx])
-    assert np.all(bboxes[1] == [[0, 0], [1, 1]])
-    assert np.all(bboxes[2] == [[3, 3], [4, 5]])
+    assert np.all(bboxes[1] == [[0, 0], [2, 2]])
+    assert np.all(bboxes[2] == [[3, 3], [5, 6]])
     assert np.all(bboxes[0] == [segmentation.shape, [0, 0]])
 
 
@@ -86,22 +86,44 @@ def test_get_bboxes():
     out = utils.get_bboxes(segmentation)
 
     assert np.all(out[0] == [[7, 7], [3, 3]])
+    assert np.all(out[1] == [[0, 0], [5, 5]])
+    assert np.all(out[2] == [[0, 1], [8, 9]])
+
+
+def test_get_bboxes_slack():
+    segmentation = np.zeros((10, 10), dtype=int)
+    segmentation[:2, :2] = 1
+    segmentation[3:5, 4:6] = 2
+    out = utils.get_bboxes(segmentation, slack=(-1, 2, 2))
+
+    assert np.all(out[0] == [[8, 8], [2, 2]])
     assert np.all(out[1] == [[0, 0], [4, 4]])
-    assert np.all(out[2] == [[0, 1], [7, 8]])
+    assert np.all(out[2] == [[1, 2], [7, 8]])
+
+
+def test_get_bboxes_no_slack():
+    segmentation = np.zeros((10, 10), dtype=int)
+    segmentation[:2, :2] = 1
+    segmentation[3:5, 4:6] = 2
+    out = utils.get_bboxes(segmentation, slack=(-1, 0, 0))
+
+    assert np.all(out[0] == [[10, 10], [0, 0]])
+    assert np.all(out[1] == [[0, 0], [2, 2]])
+    assert np.all(out[2] == [[3, 4], [5, 6]])
 
 
 def test_get_idx_slice():
     bboxes = {
         0: [[7, 7], [3, 3]],
-        1: [[0, 0], [4, 4]],
+        1: [[0, 0], [8, 4]],
         2: [[0, 1], [7, 8]],
     }
     out = utils.get_idx_slice(1, bboxes)
-    assert out[0] == (slice(0, 4), slice(0, 4))
+    assert out[0] == (slice(0, 8), slice(0, 4))
     assert np.all(out[1] == bboxes[1])
     assert np.all(out[2] == [0, 0])
 
     out = utils.get_idx_slice([1, 2], bboxes)
-    assert out[0] == (slice(0, 7), slice(0, 8))
-    assert np.all(out[1] == [[0, 0], [7, 8]])
+    assert out[0] == (slice(0, 8), slice(0, 8))
+    assert np.all(out[1] == [[0, 0], [8, 8]])
     assert np.all(out[2] == [0, 0])


### PR DESCRIPTION
Backport of #542 to plantseg 2.0.0rc12

* fix: bounding boxes are now half-open intervals

* chore: deduplicate bounding box code

see #540